### PR TITLE
Create initial snmptools ver. 'Not Found'

### DIFF
--- a/snmptools.sls
+++ b/snmptools.sls
@@ -1,9 +1,15 @@
+# just 32-bit x86 installer available
+{% if grains['cpuarch'] == 'AMD64' %}
+    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
+{% else %}
+    {% set PROGRAM_FILES = "%ProgramFiles%" %}
+{% endif %}
 snmptools:
   Not Found:
-    full_name:  'SnmpTools 2'
+    full_name: 'SnmpTools 2'
     installer: 'http://erwan.labalec.fr/snmptools/snmptools32.exe'
     install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
-    uninstaller: '%PROGRAMFILES(x86)%\SnmpTools\unins000.exe'
+    uninstaller: '{{ PROGRAM_FILES }}\SnmpTools\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART'
     msiexec: False
     locale: en_US


### PR DESCRIPTION
@m03 found the following work-around:
The SnmpTools installer doesn't populate the DisplayVersion, and pkg.version / pkg.list_pkgs reports the version as Not Found. Using Not Found as the version in the package file seems to work, with the pkg.* execution modules operating normally, and the pkg.installed state module correctly detecting when it's already installed (see this Gist https://gist.github.com/m03/4b444666290574795ff7 for an example). If there's a better official way to handle this, I can modify the package files accordingly.