### PR TITLE
Fixed for Windows osversions 6.1 and above

### DIFF
--- a/wmf3.sls
+++ b/wmf3.sls
@@ -2,17 +2,17 @@ wmf3:
   Not Found:
     {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.0') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.1') %}
     full_name: 'Windows Management Framework 3 (KB2506146)'
-    {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.2') %}
+    {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') %}
     full_name: 'Windows Management Framework 3 (KB2506143)'
     {% endif %}
     {% if grains['cpuarch'] == 'AMD64' %}
-    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.2') %}
+    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') %}
     installer: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.1-KB2506143-x64.msu'
     {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.0') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.1') %}
     installer: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.0-KB2506146-x64.msu'
     {% endif %}
     {% elif grains['cpuarch'] == 'x86' %}
-    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.2') %}
+    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') %}
     installer: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.1-KB2506143-x86.msu'
     {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.0') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.1') %}
     installer: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.0-KB2506146-x86.msu'
@@ -20,13 +20,13 @@ wmf3:
     {% endif %}
     install_flags: '/quiet /warnrestart'
     {% if grains['cpuarch'] == 'AMD64' %}
-    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.2') %}
+    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') %}
     uninstaller: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.1-KB2506143-x64.msu'
     {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.0') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.1') %}
     uninstaller: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.0-KB2506146-x64.msu'
     {% endif %}
     {% elif grains['cpuarch'] == 'x86' %}
-    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.2') %}
+    {% if salt['pkg.compare_versions'](grains['osversion'], '>=', '6.1') %}
     uninstaller: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.1-KB2506143-x86.msu'
     {% elif salt['pkg.compare_versions'](grains['osversion'], '>=', '6.0') and salt['pkg.compare_versions'](grains['osversion'], '<', '6.1') %}
     uninstaller: 'http://download.microsoft.com/download/E/7/6/E76850B8-DA6E-4FF5-8CCE-A24FC513FD16/Windows6.0-KB2506146-x86.msu'


### PR DESCRIPTION
This was causing pkg.refresh_db to fail on Windows 2012R2 (6.3) because it didn't match the versions specified, therefore required variables weren't being created.
`full_name`
`installer`
`uninstaller`