### PR TITLE
Added single quotes to version for ccleaner

### DIFF
--- a/ccleaner.sls
+++ b/ccleaner.sls
@@ -5,7 +5,7 @@
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
 ccleaner:
-  5.10:
+  '5.10':
     full_name: 'CCleaner'
     installer: 'http://download.piriform.com/ccsetup510.exe'
     install_flags: '/S'
@@ -14,7 +14,7 @@ ccleaner:
     msiexec: False
     locale: en_US
     reboot: False
-  5.0.9:
+  '5.0.9':
     full_name: 'CCleaner 5.09'
     installer: 'http://download.piriform.com/ccsetup509.exe'
     install_flags: '/S'


### PR DESCRIPTION
Fixes #27433

Version numbers that look like standard decimal numbers are evaluated to
float type variables and lose trailing zeros. To avoid this, all version
numbers must be quoted.