### PR TITLE
Downgraded git to ver. 2.6.2

### DIFF
--- a/git.sls
+++ b/git.sls
@@ -1,19 +1,6 @@
 # both 32-bit (x86) AND a 64-bit (AMD64) installer available
 {% set PROGRAM_FILES = "%ProgramFiles%" %}
 git:
-  '2.6.3':
-    full_name: 'Git version 2.6.3'
-    {% if grains['cpuarch'] == 'AMD64' %}
-    installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.3.windows.1/Git-2.6.3-64-bit.exe'
-    {% elif grains['cpuarch'] == 'x86' %}
-    installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.3.windows.1/Git-2.6.3-32-bit.exe'
-    {% endif %}
-    install_flags: '/VERYSILENT /NORESTART /SP- /NOCANCEL'
-    uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
-    uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '2.6.2':
     full_name: 'Git version 2.6.2'
     {% if grains['cpuarch'] == 'AMD64' %}


### PR DESCRIPTION
ver. 2.6.3 had an installation regression see https://github.com/saltstack/salt-winrepo-ng/issues/142