### PR TITLE
fix ccleaner, gimp versions loop

### DIFF
--- a/ccleaner.sls
+++ b/ccleaner.sls
@@ -4,8 +4,8 @@
 {% else %}
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
-{% for version, dl_version in (('5.12', '512'), ('5.11', '511'), ('5.10', '510'), ('5.0.9', '509')) %}
 ccleaner:
+  {% for version, dl_version in (('5.13', '513'), ('5.12', '512'), ('5.11', '511'), ('5.10', '510'), ('5.0.9', '509')) %}
   '{{ version }}':
     full_name: 'CCleaner'
     installer: 'http://download.piriform.com/ccsetup{{ dl_version }}.exe'
@@ -15,4 +15,4 @@ ccleaner:
     msiexec: False
     locale: en_US
     reboot: False
-{% endfor %}
+  {% endfor %}

--- a/gimp.sls
+++ b/gimp.sls
@@ -1,16 +1,17 @@
 # just 32-bit x86 installer available
+# Gimp installs into %ProgramFiles anyway
 {% if grains['cpuarch'] == 'AMD64' %}
     {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
 {% else %}
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
 gimp:
-  {% for version, minor_version in (('2.8.16', ''), ('2.8.14','-1'), ('2.8.10', ''), ('2.8.8', ''), ('2.8.4', ''), ('2.8.2', '-1'), ('2.8.0','')) %}
+  {% for version, dl_version in (('2.8.16', ''), ('2.8.14','-1'), ('2.8.10', ''), ('2.8.8', ''), ('2.8.4', ''), ('2.8.2', '-1'), ('2.8.0','')) %}
   {{ version }}:
     full_name: 'GIMP {{ version }}'
-    installer: 'http://download.gimp.org/mirror/pub/gimp/v2.8/windows/gimp-{{ version }}-setup{{ minor_version }}.exe'
+    installer: 'http://download.gimp.org/mirror/pub/gimp/v2.8/windows/gimp-{{ version }}-setup{{ dl_version }}.exe'
     install_flags: '/SP- /SILENT /NORESTART'
-    uninstaller: '{{ PROGRAM_FILES }}\Gimp 2\uninst\unins000.exe'
+    uninstaller: '%ProgramFiles%\Gimp 2\uninst\unins000.exe'
     uninstall_flags: '/SP- /SILENT /NORESTART'
     msiexec: False
     locale: en_US

--- a/gimp.sls
+++ b/gimp.sls
@@ -5,12 +5,14 @@
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
 gimp:
-  '2.8.14':
-    full_name: 'GIMP 2.8.14'
-    installer: 'http://gimper.net/downloads/pub/gimp/stable/windows/gimp-2.8.14-setup-1.exe'
+  {% for version, minor_version in (('2.8.16', ''), ('2.8.14','-1'), ('2.8.10', ''), ('2.8.8', ''), ('2.8.4', ''), ('2.8.2', '-1'), ('2.8.0','')) %}
+  {{ version }}:
+    full_name: 'GIMP {{ version }}'
+    installer: 'http://download.gimp.org/mirror/pub/gimp/v2.8/windows/gimp-{{ version }}-setup{{ minor_version }}.exe'
     install_flags: '/SP- /SILENT /NORESTART'
     uninstaller: '{{ PROGRAM_FILES }}\Gimp 2\uninst\unins000.exe'
     uninstall_flags: '/SP- /SILENT /NORESTART'
     msiexec: False
     locale: en_US
     restart: False
+  {% endfor %}


### PR DESCRIPTION
1. The "ccleaner:" statement is now outside the version for-loop. Before that the ccleaner.sls was not working.
2. Version updated to 5.13