### PR TITLE
Update gimp.sls

### DIFF
--- a/gimp.sls
+++ b/gimp.sls
@@ -1,12 +1,7 @@
 # just 32-bit x86 installer available
 # Gimp installs into %ProgramFiles anyway
-{% if grains['cpuarch'] == 'AMD64' %}
-    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
-{% else %}
-    {% set PROGRAM_FILES = "%ProgramFiles%" %}
-{% endif %}
 gimp:
-  {% for version, dl_version in (('2.8.16', ''), ('2.8.14','-1'), ('2.8.10', ''), ('2.8.8', ''), ('2.8.4', ''), ('2.8.2', '-1'), ('2.8.0','')) %}
+  {% for version, dl_version in (('2.8.14','-1'), ('2.8.10', ''), ('2.8.8', ''), ('2.8.4', ''), ('2.8.2', '-1'), ('2.8.0','')) %}
   {{ version }}:
     full_name: 'GIMP {{ version }}'
     installer: 'http://download.gimp.org/mirror/pub/gimp/v2.8/windows/gimp-{{ version }}-setup{{ dl_version }}.exe'


### PR DESCRIPTION
There is no released version 2.8.16 available - yet. (and it was missing a dl_version number as well.)