### PR TITLE
Wireshark version update

### DIFF
--- a/wireshark.sls
+++ b/wireshark.sls
@@ -1,13 +1,14 @@
 # both 32-bit (x86) AND a 64-bit (AMD64) installer available
 {% set PROGRAM_FILES = "%ProgramFiles%" %}
 wireshark:
-  '1.12.6':
+  {% for version in '2.0.0', '1.12.8' %}
+  '{{ version }}':
     {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'Wireshark 1.12.6 (64-bit)'
-    installer: 'http://wiresharkdownloads.riverbed.com/wireshark/win64/Wireshark-win64-1.12.6.exe'
+    full_name: 'Wireshark {{ version }} (64-bit)'
+    installer: 'https://1.na.dl.wireshark.org/win64/Wireshark-win64-{{ version }}.exe'
     {% elif grains['cpuarch'] == 'x86' %}
-    full_name: 'Wireshark 1.12.6'
-    installer: 'http://wiresharkdownloads.riverbed.com/wireshark/win64/Wireshark-win32-1.12.6.exe'
+    full_name: 'Wireshark {{ version }}'
+    installer: 'https://2.na.dl.wireshark.org/win32/Wireshark-win32-{{ version }}.exe'
     {% endif %}
     install_flags: '/S /desktopicon=yes /quicklaunchicon=yes'
     uninstaller: '{{ PROGRAM_FILES }}\Wireshark\uninstall.exe'
@@ -15,17 +16,4 @@ wireshark:
     msiexec: False
     locale: en_US
     reboot: False
-  '1.12.1':
-    {% if grains['cpuarch'] == 'AMD64' %}
-    full_name:  'Wireshark 1.12.1 (64-bit)'
-    installer: 'http://wiresharkdownloads.riverbed.com/wireshark/win64/Wireshark-win64-1.12.1.exe'
-    {% elif grains['cpuarch'] == 'x86' %}
-    full_name:  'Wireshark 1.12.1'
-    installer: 'http://wiresharkdownloads.riverbed.com/wireshark/win64/Wireshark-win32-1.12.1.exe'
-    {% endif %}    
-    install_flags: '/S /desktopicon=yes /quicklaunchicon=yes'
-    uninstaller: '{{ PROGRAM_FILES }}\Wireshark\uninstall.exe'
-    uninstall_flags: '/S'
-    msiexec: False
-    locale: en_US
-    reboot: False
+  {% endfor %}


### PR DESCRIPTION
Updated versions to 2.0.0 and 1.12.8 (older versions seem to be no longer available).

WinPcap must now be installed separately (tested only for 2.0.0 version).