### PR TITLE
update adding 3.6.2 to tortoise-hg

### DIFF
--- a/tortoise-hg.sls
+++ b/tortoise-hg.sls
@@ -1,5 +1,20 @@
 # Source: http://tortoisehg.bitbucket.org/
 tortoise-hg:
+  '3.6.2':
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'TortoiseHg 3.6.2 (x64)'
+    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x64.msi'
+    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x64.msi'
+    {% elif grains['cpuarch'] == 'x86' %}
+    full_name: 'TortoiseHg 3.6.2 (x86)'
+    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x86.msi'
+    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x86.msi'
+    {% endif %}
+    install_flags: '/qn /norestart'    
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False  
   '3.3.0':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'TortoiseHg 3.3.0 (x64)'


### PR DESCRIPTION
A newer version of tortoise-hg is available.  This adds support for the newer version