### PR TITLE
Fix 'full_name' of reader version 10.1.4

### DIFF
--- a/adobereader.sls
+++ b/adobereader.sls
@@ -1,6 +1,6 @@
 adobereader:
   '10.1.4':
-    full_name: 'Adobe Reader 10.1.4'
+    full_name: 'Adobe Reader X (10.1.4)'
     installer: 'http://ardownload.adobe.com/pub/adobe/reader/win/10.x/10.1.4/en_US/AdbeRdr1014_en_US.exe'
     install_flags: '/msi EULA_ACCEPT=YES REMOVE_PREVIOUS=YES ALLUSERS=1 /qn /norestart'
     uninstaller: 'msiexec.exe'


### PR DESCRIPTION
Somewhere along the line the installer has changed the name of the package in the registry  from 'Adobe Reader 10.1.4' to "Adobe Reader X (10.1.4)"