### PR TITLE
Correct broken URLs for NSClient 0.4 releases.

### DIFF
--- a/nsclient.sls
+++ b/nsclient.sls
@@ -2,12 +2,12 @@ nsclient:
   '0.4.4.19':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name:  'NSClient++ (x64)'
-    installer: 'http://files.nsclient.org/released/NSCP-0.4.4.19-x64.msi'
-    uninstaller: 'http://files.nsclient.org/released/NSCP-0.4.4.19-x64.msi'
+    installer: 'https://github.com/mickem/nscp/releases/download/0.4.4.19/NSCP-0.4.4.19-x64.msi'
+    uninstaller: 'https://github.com/mickem/nscp/releases/download/0.4.4.19/NSCP-0.4.4.19-x64.msi'
     {% elif grains['cpuarch'] == 'x86' %}
     full_name:  'NSClient++'
-    installer: 'http://files.nsclient.org/released/NSCP-0.4.4.19-Win32.msi'
-    uninstaller: 'http://files.nsclient.org/released/NSCP-0.4.4.19-Win32.msi'
+    installer: 'https://github.com/mickem/nscp/releases/download/0.4.4.19/NSCP-0.4.4.19-Win32.msi'
+    uninstaller: 'https://github.com/mickem/nscp/releases/download/0.4.4.19/NSCP-0.4.4.19-Win32.msi'
     {% endif %}
     install_flags: '/quiet'
     uninstall_flags: '/quiet'
@@ -17,12 +17,12 @@ nsclient:
   '0.4.3.88':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name:  'NSClient++ (x64)'
-    installer: 'http://files.nsclient.org/released/NSCP-0.4.3.88-x64.msi'
-    uninstaller: 'http://files.nsclient.org/released/NSCP-0.4.3.88-x64.msi'
+    installer: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-x64.msi'
+    uninstaller: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-x64.msi'
     {% elif grains['cpuarch'] == 'x86' %}
     full_name:  'NSClient++'
-    installer: 'http://files.nsclient.org/released/NSCP-0.4.3.88-Win32.msi'
-    uninstaller: 'http://files.nsclient.org/released/NSCP-0.4.3.88-Win32.msi'
+    installer: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-Win32.msi'
+    uninstaller: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-Win32.msi'
     {% endif %}
     install_flags: '/quiet'
     uninstall_flags: '/quiet'


### PR DESCRIPTION
It looks like the URLs for NSClient are broken and have been moved to the GitHub page. I updated the 0.4 releases accordingly & tested pushing to a salt-minion.