### PR TITLE
Update vagrant.sls

### DIFF
--- a/vagrant.sls
+++ b/vagrant.sls
@@ -1,10 +1,10 @@
 vagrant:
-  {% for version in '1.7.4', '1.7.3', '1.7.2', '1.7.1', '1.6.5','1.6.4','1.6.3', '1.6.2', '1.6.1', '1.6.0', '1.5.4', '1.5.3', '1.5.2', '1.5.1', '1.5.0', '1.4.3', '1.4.2', '1.4.1', '1.4.0' %}
+  {% for version in '1.8.1', '1.8.0', '1.7.4', '1.7.3', '1.7.2', '1.7.1', '1.6.5','1.6.4','1.6.3', '1.6.2', '1.6.1', '1.6.0', '1.5.4', '1.5.3', '1.5.2', '1.5.1', '1.5.0', '1.4.3', '1.4.2', '1.4.1', '1.4.0' %}
   '{{ version }}':
-    full_name: 'Vagrant {{ version }} Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_{{ version }}.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/{{ version }}/vagrant_{{ version }}.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_{{ version }}.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/{{ version }}/vagrant_{{ version }}.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US


### PR DESCRIPTION
Vagrant. Added versions 1.8.1, 1.8.0. Previous URLs not available now and they will be changed to official download links. Full name changed.