### PR TITLE
Swap strawberryperl version numbers around for ver. 5.20.3002

### DIFF
--- a/strawberryperl_x64.sls
+++ b/strawberryperl_x64.sls
@@ -1,5 +1,5 @@
 strawberryperl_x64:
-  {% for version, dl_version in (('5.22.1', '5.22.0.1'), ('5.20.3.2', '5.20.3002')) %}
+  {% for version, dl_version in (('5.22.1', '5.22.0.1'), ('5.20.3002', '5.20.3.2')) %}
   '{{ version }}':
     full_name: 'Strawberry Perl (64-bit)'
     installer: 'http://strawberryperl.com/download/{{ dl_version }}/strawberry-perl-{{ dl_version }}-64bit.msi'

--- a/strawberryperl_x86.sls
+++ b/strawberryperl_x86.sls
@@ -1,5 +1,5 @@
 strawberryperl_x86:
-  {% for version, dl_version in (('5.22.1', '5.22.0.1'), ('5.20.3.2', '5.20.3002')) %}
+  {% for version, dl_version in (('5.22.1', '5.22.0.1'), ('5.20.3002', '5.20.3.2')) %}
   '{{ version }}':
     full_name: 'Strawberry Perl'
     installer: 'http://strawberryperl.com/download/{{ dl_version }}/strawberry-perl-{{ dl_version }}-32bit.msi'


### PR DESCRIPTION
@twangboy The numbers for 5.22.1 were in the right sequence, but the 5.20.3002 ones were reversed.