### PR TITLE
Remove Notepad++ 6.8.9 (removed from site)

### DIFF
--- a/npp.sls
+++ b/npp.sls
@@ -5,7 +5,7 @@
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
 {% endif %}
 npp:
-  {% for version in '6.8.9', '6.8.8', '6.8.7', '6.8.6', '6.8.5', '6.8.4', '6.8.3', '6.8.2', '6.8.1', '6.8', '6.7.9.2', '6.7.8.2', '6.7.4', '6.4.2' %}
+  {% for version in '6.8.8', '6.8.7', '6.8.6', '6.8.5', '6.8.4', '6.8.3', '6.8.2', '6.8.1', '6.8', '6.7.9.2', '6.7.8.2', '6.7.4', '6.4.2' %}
   '{{ version }}':
     full_name: Notepad++
     installer: 'https://notepad-plus-plus.org/repository/6.x/{{ version }}/npp.{{ version }}.Installer.exe'


### PR DESCRIPTION
Removed according to https://notepad-plus-plus.org/news/v6.8.9-has-been-removed.html