### PR TITLE
Supporting Firefox install in x64

### DIFF
--- a/7zip.sls
+++ b/7zip.sls
@@ -14,5 +14,5 @@
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/7zip_beta.sls
+++ b/7zip_beta.sls
@@ -15,5 +15,5 @@
     uninstall_flags: '/S'
     msiexec: False
     reboot: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
   {% endfor %}

--- a/activeperl_x64.sls
+++ b/activeperl_x64.sls
@@ -7,6 +7,6 @@ activeperl_x64:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/activeperl_x86.sls
+++ b/activeperl_x86.sls
@@ -7,6 +7,6 @@ activeperl_x86:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/adobeair.sls
+++ b/adobeair.sls
@@ -6,7 +6,7 @@ adobeair:
     uninstaller: 'c:\salt\var\cache\salt\minion\extrn_files\base\airdownload.adobe.com\air\win\download\20.0\AdobeAIRInstaller.exe'
     uninstall_flags: '-uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '19.0.0.241':
     full_name: 'Adobe AIR'
@@ -15,7 +15,7 @@ adobeair:
     uninstaller: 'c:\salt\var\cache\salt\minion\extrn_files\base\airdownload.adobe.com\air\win\download\19.0\AdobeAIRInstaller.exe'
     uninstall_flags: '-uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '18.0.0.199':
     full_name: 'Adobe AIR'
@@ -24,5 +24,5 @@ adobeair:
     uninstaller: 'c:\salt\var\cache\salt\minion\extrn_files\base\airdownload.adobe.com\air\win\download\18.0\AdobeAIRInstaller.exe'
     uninstall_flags: '-uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/adobeflashplayeractivex.sls
+++ b/adobeflashplayeractivex.sls
@@ -7,7 +7,7 @@ adobeflashplayeractivex:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_20_active_x.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '19.0.0.245':
     full_name: 'Adobe Flash Player 19 ActiveX'
@@ -16,7 +16,7 @@ adobeflashplayeractivex:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_19_active_x.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '18.0.0.241':
     full_name: 'Adobe Flash Player 18 ActiveX'
@@ -25,7 +25,7 @@ adobeflashplayeractivex:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_18_active_x.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '16.0.0.296':
     full_name: 'Adobe Flash Player 16 ActiveX'
@@ -34,6 +34,6 @@ adobeflashplayeractivex:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_16_active_x.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 {% endif %}

--- a/adobeflashplayerplugin.sls
+++ b/adobeflashplayerplugin.sls
@@ -6,7 +6,7 @@ adobeflashplayerplugin:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_20_plugin.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '19.0.0.245':
     full_name: 'Adobe Flash Player 19 NPAPI'
@@ -15,7 +15,7 @@ adobeflashplayerplugin:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_19_plugin.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '18.0.0.241':
     full_name: 'Adobe Flash Player 18 NPAPI'
@@ -24,7 +24,7 @@ adobeflashplayerplugin:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_18_plugin.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '16.0.0.296':
     full_name: 'Adobe Flash Player 16 NPAPI'
@@ -33,5 +33,5 @@ adobeflashplayerplugin:
     uninstaller: 'http://fpdownload.macromedia.com/get/flashplayer/current/licensing/win/install_flash_player_16_plugin.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/adobereader-dc.sls
+++ b/adobereader-dc.sls
@@ -6,7 +6,7 @@ adobereader-dc:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AC0F074E4100} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2015.009.20069':
     full_name: 'Adobe Acrobat Reader DC'
@@ -15,7 +15,7 @@ adobereader-dc:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AC0F074E4100} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2015.008.20082':
     full_name: 'Adobe Acrobat Reader DC'
@@ -24,5 +24,5 @@ adobereader-dc:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AC0F074E4100} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/adobereader-xi.sls
+++ b/adobereader-xi.sls
@@ -6,7 +6,7 @@ adobereader-xi:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AB0000000001} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '11.0.6':
     full_name: 'Adobe Reader XI (11.0.06)'
@@ -15,5 +15,5 @@ adobereader-xi:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AB0000000001} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/adobereader.sls
+++ b/adobereader.sls
@@ -6,7 +6,7 @@ adobereader:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AA1000000001} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '9.5.0':
     full_name: 'Adobe Reader 9.5.0'
@@ -15,5 +15,5 @@ adobereader:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-A95000000001} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/adobeshockwaveplayer.sls
+++ b/adobeshockwaveplayer.sls
@@ -6,7 +6,7 @@ adobeshockwaveplayer:
     uninstaller: 'https://fpdownload.macromedia.com/get/shockwave/default/english/win95nt/latest/sw_lic_full_installer.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 #
 # Adobe only makes one single *.msi available for the 12.1 series, so this file will get updated and might then install a newer version

--- a/adv-ip-scanner.sls
+++ b/adv-ip-scanner.sls
@@ -6,7 +6,7 @@ adv-ip-scanner:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /noreboot /x {C3CF783A-5457-4989-966F-7BE08812FB71}'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # it can be manually downloaded from:
 # http://www.advanced-ip-scanner.com

--- a/adv-port-scanner.sls
+++ b/adv-port-scanner.sls
@@ -6,7 +6,7 @@ adv-port-scanner:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /noreboot /x {10F177CF-543F-4BC2-A297-DBF73709D3C5}'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # it can be manually downloaded from:
 # http://www.advanced-port-scanner.com

--- a/advancedlogging.sls
+++ b/advancedlogging.sls
@@ -11,5 +11,5 @@ advancedlogging:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/applicationrequestrouting.sls
+++ b/applicationrequestrouting.sls
@@ -11,5 +11,5 @@ applicationrequestrouting:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/aspnet-mvc1.sls
+++ b/aspnet-mvc1.sls
@@ -6,5 +6,5 @@ aspnet-mvc1:
     uninstaller: '{A4394612-D02F-11DC-9BFF-D18556D89593}'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/audacity.sls
+++ b/audacity.sls
@@ -11,7 +11,7 @@ audacity:
     uninstaller: '{{ PROGRAM_FILES }}\Audacity\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.0.6':
     full_name: 'Audacity 2.0.6'
@@ -20,7 +20,7 @@ audacity:
     uninstaller: '{{ PROGRAM_FILES }}\Audacity\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.0.3': 
     full_name: 'Audacity 2.0.3'
@@ -29,5 +29,5 @@ audacity:
     uninstaller: '{{ PROGRAM_FILES }}\Audacity\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/autohotkey.sls
+++ b/autohotkey.sls
@@ -11,7 +11,7 @@ autohotkey:
     uninstaller: '{{ PROGRAM_FILES }}\AutoHotKey\AutoHotKey.exe'
     uninstall_flags: '"{{ PROGRAM_FILES }}\AutoHotkey\Installer.ahk" /Uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.1.22.02':
     full_name: 'AutoHotkey 1.1.22.02'
@@ -20,7 +20,7 @@ autohotkey:
     uninstaller: '{{ PROGRAM_FILES }}\AutoHotKey\AutoHotKey.exe'
     uninstall_flags: '"{{ PROGRAM_FILES }}\AutoHotkey\Installer.ahk" /Uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.1.22.01':
     full_name: 'AutoHotkey 1.1.22.01'
@@ -29,7 +29,7 @@ autohotkey:
     uninstaller: '{{ PROGRAM_FILES }}\AutoHotKey\AutoHotKey.exe'
     uninstall_flags: '"{{ PROGRAM_FILES }}\AutoHotkey\Installer.ahk" /Uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.1.19.03':
     full_name: 'AutoHotkey 1.1.19.03'
@@ -38,5 +38,5 @@ autohotkey:
     uninstaller: '{{ PROGRAM_FILES }}\AutoHotKey\AutoHotKey.exe'
     uninstall_flags: '"{{ PROGRAM_FILES }}\AutoHotkey\Installer.ahk" /Uninstall'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/autoit.sls
+++ b/autoit.sls
@@ -10,5 +10,5 @@ autoit:
     {% endif %}
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/autopsy.sls
+++ b/autopsy.sls
@@ -11,7 +11,7 @@ autopsy:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.1.3': 
     full_name: 'Autopsy'
@@ -25,7 +25,7 @@ autopsy:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.1.2': 
     full_name: 'Autopsy'
@@ -39,7 +39,7 @@ autopsy:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.1.1': 
     full_name: 'Autopsy'
@@ -53,5 +53,5 @@ autopsy:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/awscli.sls
+++ b/awscli.sls
@@ -14,5 +14,5 @@ awscli:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False 

--- a/bandizip.sls
+++ b/bandizip.sls
@@ -6,5 +6,5 @@ bandizip:
     uninstaller: '%ProgramFiles%\Bandizip\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/bitnami-nginxstack.sls
+++ b/bitnami-nginxstack.sls
@@ -7,5 +7,5 @@ bitnami-nginxstack:
     uninstaller: 'C:\Bitnami\nginxstack-1.8.0-0\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/blender.sls
+++ b/blender.sls
@@ -13,7 +13,7 @@ blender:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart' 
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.75':
     full_name: 'Blender'
@@ -27,5 +27,5 @@ blender:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart' 
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/bulk_extractor.sls
+++ b/bulk_extractor.sls
@@ -12,7 +12,7 @@ bulk_extractor:
     uninstaller: '{{ PROGRAM_FILES }}\Bulk Extractor 1.5.5\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.4.1':
     full_name: 'bulk_extractor'
@@ -21,5 +21,5 @@ bulk_extractor:
     uninstaller: '{{ PROGRAM_FILES }}\Bulk Extractor 1.4.1\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ccleaner.sls
+++ b/ccleaner.sls
@@ -13,6 +13,6 @@ ccleaner:
     uninstaller: '{{ PROGRAM_FILES }}\CCleaner\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/cdburnerxp.sls
+++ b/cdburnerxp.sls
@@ -12,5 +12,5 @@ cdburnerxp:
     uninstaller: '{{ PROGRAM_FILES }}\CDBurnerXP\unins000.exe'
     uninstall_flags: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/cdex.sls
+++ b/cdex.sls
@@ -12,7 +12,7 @@ cdex:
     uninstaller: '{{ PROGRAM_FILES }}\CDex\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.75':
     full_name: 'CDex - Open Source Digital Audio CD Extractor'
@@ -21,7 +21,7 @@ cdex:
     uninstaller: '{{ PROGRAM_FILES }}\CDex\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.72':
     full_name: 'CDex - Open Source Digital Audio CD Extractor'
@@ -30,5 +30,5 @@ cdex:
     uninstaller: '{{ PROGRAM_FILES }}\CDex\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/cdroller.sls
+++ b/cdroller.sls
@@ -12,7 +12,7 @@ cdroller:
     uninstaller: '{{ PROGRAM_FILES }}\CDRoller\unins000.exe'
     uninstall_flags: '/VERYSILENT'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '9.70':
     full_name: 'CDRoller'
@@ -21,5 +21,5 @@ cdroller:
     uninstaller: '{{ PROGRAM_FILES }}\CDRoller 9.70\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/check-mk-agent-msi.sls
+++ b/check-mk-agent-msi.sls
@@ -7,6 +7,6 @@ check-mk-agent-msi:
     uninstaller: 'salt://win/repo-ng/check_mk/check_mk_agent-{{ version }}.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/check-mk-agent.sls
+++ b/check-mk-agent.sls
@@ -10,7 +10,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.8b3'
@@ -23,7 +23,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.8b2'
@@ -36,7 +36,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.8b1'
@@ -49,7 +49,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.7i3p5'
@@ -62,7 +62,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.7i3p4'
@@ -75,7 +75,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.7i3p3'
@@ -88,7 +88,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.7i3p2'
@@ -101,7 +101,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.7i3p1'
@@ -114,7 +114,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.6p16'
@@ -127,7 +127,7 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'Check_MK Agent 1.2.6p15'
@@ -140,5 +140,5 @@ check-mk-agent:
     install_flags: '/S'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/chocolatey.sls
+++ b/chocolatey.sls
@@ -18,7 +18,7 @@ chocolatey:
                      reg DEL HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Chocolatey /f &
                      exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.9.8':
     full_name: 'Chocolatey v0.9.8'
@@ -39,7 +39,7 @@ chocolatey:
                      reg DEL HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\Chocolatey /f &
                      exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 #
 # this software also has it's own salt execution module, which you might prefer to use, see

--- a/chrome.sls
+++ b/chrome.sls
@@ -6,5 +6,5 @@ chrome:
     uninstaller: 'https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/clamav.sls
+++ b/clamav.sls
@@ -10,7 +10,7 @@ clamav:
     installer: 'salt://win/repo-ng/clamav/clamav-0.99.1-win32.msi'
     {% endif %}
     install_flags: '/qr'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     msiexec: True
     uninstaller: 'msiexec.exe'
@@ -26,7 +26,7 @@ clamav:
     installer: 'salt://win/repo-ng/clamav/clamav-0.98.7-win32.msi'
     {% endif %}
     install_flags: '/qr'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     msiexec: True
     uninstaller: 'msiexec.exe'

--- a/clamwin.sls
+++ b/clamwin.sls
@@ -12,7 +12,7 @@ clamwin:
     uninstaller: '{{ PROGRAM_FILES }}\ClamWin\unins000.exe'
     uninstall_flags: '/verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.98.6': 
     full_name: 'ClamWin'
@@ -21,7 +21,7 @@ clamwin:
     uninstaller: '{{ PROGRAM_FILES }}\ClamWin\unins000.exe'
     uninstall_flags: '/verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.98.5': 
     full_name: 'ClamWin'
@@ -30,5 +30,5 @@ clamwin:
     uninstaller: '{{ PROGRAM_FILES }}\ClamWin\unins000.exe'
     uninstall_flags: '/verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/classicshell.sls
+++ b/classicshell.sls
@@ -10,5 +10,5 @@ classicshell:
     uninstall_flags: '/qn /x {B9EFC38D-E52A-4BBE-8421-58FCFFDE19E2} /norestart'
     {% endif %}
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/clink.sls
+++ b/clink.sls
@@ -12,7 +12,7 @@ clink:
     uninstaller: '{{ PROGRAM_FILES }}\clink\0.4.6\clink_uninstall_0.4.6.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.4.4':
     full_name: 'Clink v0.4.4'
@@ -21,6 +21,6 @@ clink:
     uninstaller: '{{ PROGRAM_FILES }}\clink\0.4.4\clink_uninstall_0.4.4.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 # https://mridgers.github.io/clink/

--- a/conemu-alpha.sls
+++ b/conemu-alpha.sls
@@ -15,7 +15,7 @@ conemu-alpha:
     {% endif %}
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '11.150.7160':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -31,5 +31,5 @@ conemu-alpha:
     {% endif %}
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/conemu-preview.sls
+++ b/conemu-preview.sls
@@ -15,7 +15,7 @@ conemu-preview:
     {% endif %}
     msiexec: False
     uninstaller: 'msiexec.exe'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '11.150.7050':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -31,5 +31,5 @@ conemu-preview:
     {% endif %}
     msiexec: False
     uninstaller: 'msiexec.exe'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/cpu-z.sls
+++ b/cpu-z.sls
@@ -13,7 +13,7 @@ cpu-z:
     uninstaller: '{{ PROGRAM_FILES }}\CPU-Z\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.71.1':
     full_name: 'CPUID CPU-Z 1.71.1'
@@ -22,7 +22,7 @@ cpu-z:
     uninstaller: '{{ PROGRAM_FILES }}\CPU-Z\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # need to manually download from:
 # http://www.cpuid.com/softwares/cpu-z.html (ftp DL is cookie protected)

--- a/curl.sls
+++ b/curl.sls
@@ -13,7 +13,7 @@ curl:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.45.0':
     full_name: 'cURL'
@@ -27,7 +27,7 @@ curl:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.44.0':
     full_name: 'cURL'
@@ -41,7 +41,7 @@ curl:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.43.0':
     full_name: 'cURL'
@@ -55,7 +55,7 @@ curl:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.40.0':
     full_name: 'cURL'
@@ -68,7 +68,7 @@ curl:
     {% endif %}
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 #
 # You need to download the win64 msi from website (Captcha protected) and place in your winrepo-ng on master

--- a/cyberduck-cli.sls
+++ b/cyberduck-cli.sls
@@ -6,5 +6,5 @@ cyberduck-cli:
     uninstaller: '%ALLUSERSPROFILE%\Package Cache\{546f46a5-c136-46d7-9698-8bd02eea4402}\duck-4.8.0.18560.exe'
     uninstall_flags: '/uninstall /quiet /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/cyberduck.sls
+++ b/cyberduck.sls
@@ -12,5 +12,5 @@ cyberduck:
     uninstaller: '{{ PROGRAM_FILES }}\Cyberduck\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/defraggler.sls
+++ b/defraggler.sls
@@ -12,7 +12,7 @@ defraggler:
     uninstaller: '{{ PROGRAM_FILES }}\Defraggler\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.18.945':
     full_name: 'Defraggler 2.18'
@@ -21,5 +21,5 @@ defraggler:
     uninstaller: '{{ PROGRAM_FILES }}\Defraggler\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/dotnet.sls
+++ b/dotnet.sls
@@ -11,5 +11,5 @@
     uninstall_flags: '/uninstall /x86 /q /norestart'
     {% endif %}
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/dvdstyler.sls
+++ b/dvdstyler.sls
@@ -12,5 +12,5 @@ dvdstyler:
     uninstaller: '{{ PROGRAM_FILES }}\DVDStyler\unins000.exe'
     uninstall_flags: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/eea.sls
+++ b/eea.sls
@@ -11,7 +11,7 @@ eea:
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.2254.0':
     full_name: 'ESET Endpoint Antivirus'
@@ -25,5 +25,5 @@ eea:
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/emet.sls
+++ b/emet.sls
@@ -6,7 +6,7 @@ emet:
     uninstaller: 'http://download.microsoft.com/download/7/0/A/70AF5150-10DD-4838-ACFC-C4390B05620A/EMET%205.2%20Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.1':
     full_name: 'EMET 5.1'
@@ -15,5 +15,5 @@ emet:
     uninstaller: 'http://download.microsoft.com/download/A/A/8/AA853FAE-7608-462E-B166-45B0F065BA13/EMET%205.1%20Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/emsisoft-anti-malware.sls
+++ b/emsisoft-anti-malware.sls
@@ -13,5 +13,5 @@ emsisoft-anti-malware:
     uninstaller: '{{ PROGRAM_FILES }}\Emsisoft Anti-Malware\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART /SuppressMsgBoxes'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/fiddler.sls
+++ b/fiddler.sls
@@ -12,7 +12,7 @@ fiddler:
     uninstaller: '{{ PROGRAM_FILES }}\Fiddler\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.6.2.2':
     full_name:  'Fiddler'
@@ -21,5 +21,5 @@ fiddler:
     uninstaller: '{{ PROGRAM_FILES }}\Fiddler\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/filehippo-app-manager.sls
+++ b/filehippo-app-manager.sls
@@ -13,6 +13,6 @@ filehippo-app-manager:
     uninstaller: '{{ PROGRAM_FILES }}\FileHippo.com\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # download manually and place on master salt://win/repo-ng/filehippo-app-manager

--- a/filezilla.sls
+++ b/filezilla.sls
@@ -12,7 +12,7 @@ filezilla:
     uninstaller: '{{ PROGRAM_FILES }}\FileZilla FTP Client\uninstall.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.14.1':
     full_name: 'FileZilla Client 3.14.1'
@@ -25,7 +25,7 @@ filezilla:
     uninstaller: '{{ PROGRAM_FILES }}\FileZilla FTP Client\uninstall.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.14.0':
     full_name: 'FileZilla Client 3.14.0'
@@ -38,7 +38,7 @@ filezilla:
     uninstaller: '{{ PROGRAM_FILES }}\FileZilla FTP Client\uninstall.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.13.0':
     full_name: 'FileZilla Client 3.13.0'
@@ -51,7 +51,7 @@ filezilla:
     uninstaller: '{{ PROGRAM_FILES }}\FileZilla FTP Client\uninstall.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.11.0.2':
     full_name: 'FileZilla Client 3.11.0.2'
@@ -64,5 +64,5 @@ filezilla:
     uninstaller: '{{ PROGRAM_FILES }}\FileZilla FTP Client\uninstall.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/firefox-esr.sls
+++ b/firefox-esr.sls
@@ -13,6 +13,6 @@ firefox-esr:
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Firefox\uninstall\helper.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/firefox.sls
+++ b/firefox.sls
@@ -1,14 +1,16 @@
 firefox:
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
   {% if grains['cpuarch'] == 'AMD64' %}
-    {% set arch = "win64" %}
+    {% set winarch = "win64" %}
+    {% set arch = "x64" %}
   {% else %}
-    {% set arch = "win32" %}
+    {% set winarch = "win32" %}
+    {% set arch = "x86" %}
   {% endif %}
   {% for version in '29.0.1', '31.0esr', '35.0.1', '38.0.1', '38.0.5', '38.0.6', '39.0', '39.0.3', '40.0', '40.0.1', '40.0.2', '40.0.3', '41.0', '41.0.1', '41.0.2', '42.0', '43.0', '43.0.1', '43.0.2', '43.0.3', '43.0.4', '44.0', '44.0.1', '44.0.2', '45.0' %}
   '{{ version }}':
-    full_name: 'Mozilla Firefox {{ version }} ({{grains['cpuarch']}} en-US)'
-    installer: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/{{ version }}/{{arch}}/en-US/Firefox%20Setup%20{{ version }}.exe'
+    full_name: 'Mozilla Firefox {{ version }} ({{arch}} en-US)'
+    installer: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/{{ version }}/{{winarch}}/en-US/Firefox%20Setup%20{{ version }}.exe'
     install_flags: '/s'
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Firefox\uninstall\helper.exe'
     uninstall_flags: '/S'

--- a/firefox.sls
+++ b/firefox.sls
@@ -1,13 +1,14 @@
 firefox:
-  {% if grains['cpuarch'] == 'AMD64' %}
-    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
-  {% else %}
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
+  {% if grains['cpuarch'] == 'AMD64' %}
+    {% set arch = "win64" %}
+  {% else %}
+    {% set arch = "win32" %}
   {% endif %}
   {% for version in '29.0.1', '31.0esr', '35.0.1', '38.0.1', '38.0.5', '38.0.6', '39.0', '39.0.3', '40.0', '40.0.1', '40.0.2', '40.0.3', '41.0', '41.0.1', '41.0.2', '42.0', '43.0', '43.0.1', '43.0.2', '43.0.3', '43.0.4', '44.0', '44.0.1', '44.0.2', '45.0' %}
   '{{ version }}':
-    full_name: 'Mozilla Firefox {{ version }} (x86 en-US)'
-    installer: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/{{ version }}/win32/en-US/Firefox%20Setup%20{{ version }}.exe'
+    full_name: 'Mozilla Firefox {{ version }} ({{grains['cpuarch']}} en-US)'
+    installer: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/{{ version }}/{{arch}}/en-US/Firefox%20Setup%20{{ version }}.exe'
     install_flags: '/s'
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Firefox\uninstall\helper.exe'
     uninstall_flags: '/S'

--- a/firefox.sls
+++ b/firefox.sls
@@ -13,6 +13,6 @@ firefox:
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Firefox\uninstall\helper.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/gedit.sls
+++ b/gedit.sls
@@ -12,5 +12,5 @@ gedit:
     uninstaller: '{{ PROGRAM_FILES }}\gedit\unins000.exe'
     uninstall_flags: '/verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gimp.sls
+++ b/gimp.sls
@@ -9,6 +9,6 @@ gimp:
     uninstaller: '%ProgramFiles%\Gimp 2\uninst\unins000.exe'
     uninstall_flags: '/SP- /SILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     restart: False
   {% endfor %}

--- a/git-extensions.sls
+++ b/git-extensions.sls
@@ -6,7 +6,7 @@ git-extensions:
     uninstaller: 'http://kent.dl.sourceforge.net/project/gitextensions/Git%20Extensions/Version%202.48.05/GitExtensions-2.48.05-Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.48.03':
     full_name: 'Git Extensions 2.48.03'
@@ -15,5 +15,5 @@ git-extensions:
     uninstaller: 'http://kent.dl.sourceforge.net/project/gitextensions/Git%20Extensions/Version%202.48.03/GitExtensions-2.48.03-Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/git.sls
+++ b/git.sls
@@ -12,7 +12,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.1':
     full_name: 'Git version 2.7.1'
@@ -25,7 +25,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.0':
     full_name: 'Git version 2.7.0'
@@ -38,7 +38,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.6.4':
     full_name: 'Git version 2.6.4'
@@ -51,7 +51,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.6.2':
     full_name: 'Git version 2.6.2'
@@ -64,7 +64,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.5.3':
     full_name: 'Git version 2.5.3'
@@ -77,7 +77,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.5.2.2':
     full_name: 'Git version 2.5.2.2'
@@ -90,7 +90,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.5.0':
     full_name: 'Git version 2.5.0'
@@ -103,7 +103,7 @@ git:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART & {{ PROGRAM_FILES }}\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 msysgit:
   '1.9.5-preview20150319':
@@ -113,7 +113,7 @@ msysgit:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART '
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.9.5-preview20141217':
     full_name: 'Git version 1.9.5-preview20141217'
@@ -122,7 +122,7 @@ msysgit:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.9.4-preview20140815':
     full_name: 'Git version 1.9.4-preview20140815'  
@@ -131,5 +131,5 @@ msysgit:
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NOREBOOT'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/glarysoft-absolute-uninstaller.sls
+++ b/glarysoft-absolute-uninstaller.sls
@@ -12,5 +12,5 @@ glarysoft-absolute-uninstaller:
     uninstaller: '{{ PROGRAM_FILES }}\Glarysoft\Absolute Uninstaller 5\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gnucash.sls
+++ b/gnucash.sls
@@ -12,6 +12,6 @@ gnucash:
     uninstaller: '{{ PROGRAM_FILES }}\gnucash\uninstall\gnucash\unins000.exe'
     uninstall_flags: '/SILENT'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     

--- a/golang.sls
+++ b/golang.sls
@@ -12,7 +12,7 @@ golang:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.5':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -27,7 +27,7 @@ golang:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.4.2':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -42,5 +42,5 @@ golang:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/goodsync.sls
+++ b/goodsync.sls
@@ -6,5 +6,5 @@ goodsync:
     uninstaller: 'https://www.goodsync.com/download/GoodSync-Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gow.sls
+++ b/gow.sls
@@ -12,7 +12,7 @@ gow:
     uninstaller: '{{ PROGRAM_FILES }}\Gow\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # Gow - GNU on Windows - The lightweight alternative to Cygwin
     # https://github.com/bmatzelle/gow/wiki

--- a/gpg4win-light.sls
+++ b/gpg4win-light.sls
@@ -12,7 +12,7 @@ gpg4win-light:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.2.4':
     full_name: 'Gpg4Win (2.2.4)'
@@ -21,7 +21,7 @@ gpg4win-light:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 #
 # Note: this 2.2.3 light installer has a bug and it needs to be fixed upstream 

--- a/gpg4win-vanilla.sls
+++ b/gpg4win-vanilla.sls
@@ -12,7 +12,7 @@ gpg4win-vanilla:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.2.4':
     full_name: 'Gpg4Win (2.2.4)'
@@ -21,5 +21,5 @@ gpg4win-vanilla:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gpg4win.sls
+++ b/gpg4win.sls
@@ -12,7 +12,7 @@ gpg4win:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.2.4':
     full_name: 'Gpg4Win (2.2.4)'
@@ -21,5 +21,5 @@ gpg4win:
     uninstaller: '{{ PROGRAM_FILES }}\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gpu-z.sls
+++ b/gpu-z.sls
@@ -13,7 +13,7 @@ gpu-z:
     uninstaller: '{{ PROGRAM_FILES }}\GPU-Z\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
     # alternate DL URLs
     # http://uk1-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.4.exe

--- a/grepwin.sls
+++ b/grepwin.sls
@@ -12,7 +12,7 @@ grepwin:
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.6.646':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -27,5 +27,5 @@ grepwin:
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/gvim.sls
+++ b/gvim.sls
@@ -12,7 +12,7 @@ gvim:
     uninstaller: '{{ PROGRAM_FILES }}\Vim\vim74\uninstall-gui.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.3':
     full_name:  'Vim 7.3 (self-installing)'
@@ -21,5 +21,5 @@ gvim:
     uninstaller: '{{ PROGRAM_FILES }}\Vim\vim73\uninstall-gui.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/handbrake.sls
+++ b/handbrake.sls
@@ -13,7 +13,7 @@ handbrake:
     uninstaller: '{{ PROGRAM_FILES }}\Handbrake\uninst.exe'
     uninstall_flags: '/S' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.10.2':
     full_name: 'Handbrake 0.10.2'
@@ -26,7 +26,7 @@ handbrake:
     uninstaller: '{{ PROGRAM_FILES }}\Handbrake\uninst.exe'
     uninstall_flags: '/S' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.10.0':
     full_name: 'Handbrake 0.10.0'
@@ -39,7 +39,7 @@ handbrake:
     uninstaller: '{{ PROGRAM_FILES }}\Handbrake\uninst.exe'
     uninstall_flags: '/S' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # alternative download URL 64-bit
 # https://handbrake.fr/rotation.php?file=HandBrake-0.10.0-x86_64-Win_GUI.exe

--- a/ice.sls
+++ b/ice.sls
@@ -8,7 +8,7 @@ ice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.6.0':
     full_name: 'Ice 3.6.0'
@@ -17,7 +17,7 @@ ice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.4.0':
     full_name: 'Ice 3.4.0'
@@ -26,5 +26,5 @@ ice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/icecast.sls
+++ b/icecast.sls
@@ -12,5 +12,5 @@ icecast:
     uninstaller: '{{ PROGRAM_FILES }}\Icecast\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/icloud.sls
+++ b/icloud.sls
@@ -6,7 +6,7 @@ icloud:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {4B48E22A-2FB0-4EFA-B99E-954B1E50CD69} /norestart' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.1.1.53':
     full_name: iCloud
@@ -15,5 +15,5 @@ icloud:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {709A2D23-C25E-47B5-9268-CB6FEE648504} /norestart' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/iismediaservices.sls
+++ b/iismediaservices.sls
@@ -11,7 +11,7 @@ iismediaservices:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.0.0938.54':
     full_name: 'IIS Media Services 4.0'
@@ -25,7 +25,7 @@ iismediaservices:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.0.1':
     full_name: 'IIS Media Services 2.0'
@@ -39,5 +39,5 @@ iismediaservices:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/influx-capacitor.sls
+++ b/influx-capacitor.sls
@@ -6,5 +6,5 @@ influx-capacitor:
     uninstaller: 'http://influx-capacitor.com/Resources/Production/Influx-Capacitor.1.0.15.msi'
     uninstall_flags: '/q'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/infrarecorder.sls
+++ b/infrarecorder.sls
@@ -16,5 +16,5 @@ infrarecorder:
     uninstall_flags: '/S'
     msiexec: False
     {% endif %}
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/inkscape.sls
+++ b/inkscape.sls
@@ -11,5 +11,5 @@ inkscape:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/intellij.sls
+++ b/intellij.sls
@@ -13,7 +13,7 @@ intellij-community:
     uninstaller: '{{ PROGRAM_FILES }}\JetBrains\IntelliJ IDEA Community Edition {{ version }}\bin\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}
 intellij-ultimate:
@@ -25,6 +25,6 @@ intellij-ultimate:
     uninstaller: '{{ PROGRAM_FILES }}\JetBrains\IntelliJ IDEA {{ version }}\bin\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/internet-evidence-finder.sls
+++ b/internet-evidence-finder.sls
@@ -6,5 +6,5 @@ internet-evidence-finder:
     uninstaller: 'salt://win/repo-ng/ief/IEFv623.0001setup.exe'
     uninstall_flags: '/verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/irfanview-plugins.sls
+++ b/irfanview-plugins.sls
@@ -13,7 +13,7 @@ irfanview-plugins:
     uninstaller: ''
     uninstall_flags: '' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.38':
     full_name: 'Irfanview Plugins 4.38'
@@ -23,6 +23,6 @@ irfanview-plugins:
     uninstaller: ''
     uninstall_flags: '' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # download manually from: http://www.irfanview.info/files/irfanview_plugins_438_setup.exe and place on master

--- a/irfanview.sls
+++ b/irfanview.sls
@@ -15,7 +15,7 @@ irfanview:
     uninstaller: '{{ PROGRAM_FILES }}\irfanview\iv_uninstall.exe'
     uninstall_flags: '/silent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.38':
     full_name: 'IrfanView (remove only)'
@@ -25,7 +25,7 @@ irfanview:
     uninstaller: '{{ PROGRAM_FILES }}\irfanview\iv_uninstall.exe'
     uninstall_flags: '/silent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 # install_flags
 # folder:     destination folder; if not indicated: old IrfanView folder is used, if not found, the "Program Files" folder is used

--- a/isapirewrite-lite.sls
+++ b/isapirewrite-lite.sls
@@ -11,5 +11,5 @@ isapirewrite-lite:
     install_flags: 'ALLUSERS=1 /quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/itunes.sls
+++ b/itunes.sls
@@ -39,7 +39,7 @@ itunes:
     install_flags: '/quiet /qn ALLUSERS=1 /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '12.3.0.44':
     full_name: 'iTunes'
@@ -54,7 +54,7 @@ itunes:
                      msiexec.exe /qn /norestart /x {88509E20-3936-4D88-A1C0-B274C7BB5151} &                 
                      exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # the above uninstalls:
     # Bonjour64 v. 3.1.0.1  {56DDDFB8-7F79-4480-89D5-25E1F52AB28F}
@@ -73,7 +73,7 @@ itunes:
                      msiexec.exe /qn /norestart /x {9E9CFD9F-64D6-498F-8584-E5CD08BA60BE} &                 
                      exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # the above uninstalls:
     # Bonjour v. 3.1.0.1  {D168AAD0-6686-47C1-B599-CDD4888B9D1A}
@@ -85,7 +85,7 @@ itunes:
     install_flags: '/quiet /qn ALLUSERS=1 /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '12.2.2.25':
     full_name: 'iTunes'
@@ -125,7 +125,7 @@ itunes:
     install_flags: '/quiet /qn ALLUSERS=1 /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '12.2.1.16':
     full_name: 'iTunes'
@@ -165,5 +165,5 @@ itunes:
     install_flags: '/quiet /qn ALLUSERS=1 /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/jre.sls
+++ b/jre.sls
@@ -17,7 +17,7 @@ jre:
     uninstaller: 'msiexec.exe'
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # due to winrepo installer limitations you need to manually download the exe from
     # http://javadl.sun.com/webapps/download/AutoDL?BundleId=106369

--- a/jre8.sls
+++ b/jre8.sls
@@ -22,7 +22,7 @@ jre8:
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '8.0.710.15':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -47,7 +47,7 @@ jre8:
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '8.0.660.18':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -72,7 +72,7 @@ jre8:
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '8.0.600.27':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -97,7 +97,7 @@ jre8:
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '8.0.510':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -122,5 +122,5 @@ jre8:
     install_flags: '/s REBOOT=Suppress SPONSORS=0'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/kdiff3.sls
+++ b/kdiff3.sls
@@ -10,5 +10,5 @@ kdiff3:
     uninstaller: '%PROGRAMFILES%\KDiff3\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/keepass-2x.sls
+++ b/keepass-2x.sls
@@ -6,7 +6,7 @@ keepass-2x:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%202.x/2.31/KeePass-2.31.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.30.0':
     full_name: 'KeePass 2.30'
@@ -15,7 +15,7 @@ keepass-2x:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%202.x/2.30/KeePass-2.30.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.29.0':
     full_name: 'KeePass 2.29'
@@ -24,5 +24,5 @@ keepass-2x:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%202.x/2.29/KeePass-2.29.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/keepass.sls
+++ b/keepass.sls
@@ -6,7 +6,7 @@ keepass:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%201.x/1.31/KeePass-1.31.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True    
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.30.0':
     full_name: 'KeePass 1.30'
@@ -15,7 +15,7 @@ keepass:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%201.x/1.30/KeePass-1.30.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True    
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.29.0':
     full_name: 'KeePass 1.29'
@@ -24,5 +24,5 @@ keepass:
     uninstaller: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%201.x/1.29/KeePass-1.29.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True    
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/libreoffice.sls
+++ b/libreoffice.sls
@@ -1,12 +1,12 @@
 libreoffice:
-  '5.1.0.3':
-    full_name: 'LibreOffice 5.1.0.3'
+  '5.1.1.3':
+    full_name: 'LibreOffice 5.1.1.3'
     {% if grains['cpuarch'] == 'AMD64' %}
-    installer: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.0/win/x86_64/LibreOffice_5.1.0_Win_x64.msi'
-    uninstaller: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.0/win/x86_64/LibreOffice_5.1.0_Win_x64.msi'
+    installer: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.1/win/x86_64/LibreOffice_5.1.1_Win_x64.msi'
+    uninstaller: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.1/win/x86_64/LibreOffice_5.1.1_Win_x64.msi'
     {% elif grains['cpuarch'] == 'x86' %}
-    installer: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.0/win/x86/LibreOffice_5.1.0_Win_x86.msi'
-    uninstaller: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.0/win/x86/LibreOffice_5.1.0_Win_x86.msi'
+    installer: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.1/win/x86/LibreOffice_5.1.1_Win_x86.msi'
+    uninstaller: 'http://mirror.catn.com/pub/tdf/libreoffice/stable/5.1.1/win/x86/LibreOffice_5.1.1_Win_x86.msi'
     {% endif %}
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'

--- a/libreoffice.sls
+++ b/libreoffice.sls
@@ -11,7 +11,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.4.2':
     full_name: 'LibreOffice 5.0.4.2'
@@ -25,7 +25,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.0':
     full_name: 'LibreOffice 5.0.0'
@@ -39,7 +39,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.4.5':
     full_name: 'LibreOffice 4.4.5'
@@ -48,5 +48,5 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/libreoffice.sls
+++ b/libreoffice.sls
@@ -11,7 +11,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: locale: {{grains['locale_info']['defaultlanguage']}}
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.4.2':
     full_name: 'LibreOffice 5.0.4.2'
@@ -25,7 +25,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: locale: {{grains['locale_info']['defaultlanguage']}}
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.0':
     full_name: 'LibreOffice 5.0.0'
@@ -39,7 +39,7 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: locale: {{grains['locale_info']['defaultlanguage']}}
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.4.5':
     full_name: 'LibreOffice 4.4.5'
@@ -48,5 +48,5 @@ libreoffice:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: locale: {{grains['locale_info']['defaultlanguage']}}
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/logparser.sls
+++ b/logparser.sls
@@ -6,5 +6,5 @@ logparser:
     uninstaller: 'http://download.microsoft.com/download/f/f/1/ff1819f9-f702-48a5-bbc7-c9656bc74de8/LogParser.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/malwarebytes.sls
+++ b/malwarebytes.sls
@@ -13,5 +13,5 @@ malwarebytes:
     uninstaller: '{{ PROGRAM_FILES }}\Malwarebytes Anti-Malware\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/mercurial.sls
+++ b/mercurial.sls
@@ -12,5 +12,5 @@ mercurial:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/messageanalyzer.sls
+++ b/messageanalyzer.sls
@@ -11,5 +11,5 @@ messageanalyzer:
     uninstaller: '{1CC02C23-8FCD-487E-860C-311EC0A0C933}'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/microsoft-build-tools.sls
+++ b/microsoft-build-tools.sls
@@ -11,5 +11,5 @@ microsoft-build-tools:
     install_flags: '/qn /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/mikogo.sls
+++ b/mikogo.sls
@@ -6,5 +6,5 @@ mikogo:
     uninstaller: '%AppData%\Mikogo\remover.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-mbsa.sls
+++ b/ms-mbsa.sls
@@ -15,7 +15,7 @@ ms-mbsa:
     install_flags: '/q'
     uninstall_flags: '/q'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 
 {% endwith %}

--- a/ms-vcpp-2005-atl-redist_x64.sls
+++ b/ms-vcpp-2005-atl-redist_x64.sls
@@ -7,5 +7,5 @@ ms-vcpp-2005-atl-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {6E8E85E8-CE4B-4FF5-91F7-04999C9FAE6A} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-atl-redist_x86.sls
+++ b/ms-vcpp-2005-atl-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-atl-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {A49F249F-0C91-497F-86DF-B2585E8E76B7} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-redist_x64.sls
+++ b/ms-vcpp-2005-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {071c9b48-7c32-4621-a0ac-3f809523288f} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-redist_x86.sls
+++ b/ms-vcpp-2005-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {7299052b-02a4-4627-81f2-1818da5d550d} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-sp1-mfc-redist_x64.sls
+++ b/ms-vcpp-2005-sp1-mfc-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-sp1-mfc-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {ad8a2fa1-06e7-4b0d-927d-6e54b3d31028} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-sp1-mfc-redist_x86.sls
+++ b/ms-vcpp-2005-sp1-mfc-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-sp1-mfc-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {710f4c1c-cc18-4c49-8cbf-51240c89a1a2} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-sp1-redist_x64.sls
+++ b/ms-vcpp-2005-sp1-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-sp1-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {6ce5bae9-d3ca-4b99-891a-1dc6c118a5fc} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2005-sp1-redist_x86.sls
+++ b/ms-vcpp-2005-sp1-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2005-sp1-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {837b34e3-7c30-493c-8f6a-2b0f04e2912c} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2008-redist_x64.sls
+++ b/ms-vcpp-2008-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {350AA351-21FA-3270-8B7A-835434E766AD} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2008-redist_x86.sls
+++ b/ms-vcpp-2008-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {FF66E9F6-83E7-3A3E-AF14-8DE9A809A6A4} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/ms-vcpp-2008-sp1-atl-redist_x64.sls
+++ b/ms-vcpp-2008-sp1-atl-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-sp1-atl-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {4B6C7001-C7D6-3710-913E-5BC23FCE91E6} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2008-sp1-atl-redist_x86.sls
+++ b/ms-vcpp-2008-sp1-atl-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-sp1-atl-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {1F1C2DFC-2D24-3E06-BCB8-725134ADF989} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2008-sp1-mfc-redist_x64.sls
+++ b/ms-vcpp-2008-sp1-mfc-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-sp1-mfc-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2008-sp1-mfc-redist_x86.sls
+++ b/ms-vcpp-2008-sp1-mfc-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2008-sp1-mfc-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {9BE518E6-ECC6-35A9-88E4-87755C07200F} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2010-sp1-mfc-redist_64.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2010-sp1-mfc-redist_x64:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {1D8E6291-B0D5-35EC-8441-6616F567A0F7} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2010-sp1-mfc-redist_x86.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2010-sp1-mfc-redist_x86:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {F0C3E5D1-1ADE-321E-8167-68EF0DE699A5} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2012-redist_x64.sls
+++ b/ms-vcpp-2012-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2012-redist_x64:
     uninstaller: '%ProgramData%\Package Cache\{ca67548a-5ebe-413a-b50c-4b9ceb6d66c6}\vcredist_x64.exe'
     uninstall_flags: '/quiet /uninstall /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2012-redist_x86.sls
+++ b/ms-vcpp-2012-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2012-redist_x86:
     uninstaller: '"%ProgramData%\Package Cache\{33d1fd90-4274-48a1-9bc1-97e33d9c2d6f}\vcredist_x86.exe"'
     uninstall_flags: '/uninstall /quiet /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2013-redist_x64.sls
+++ b/ms-vcpp-2013-redist_x64.sls
@@ -6,5 +6,5 @@ ms-vcpp-2013-redist_x64:
     uninstaller: 'http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe'
     uninstall_flags: '/uninstall /quiet /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2013-redist_x86.sls
+++ b/ms-vcpp-2013-redist_x86.sls
@@ -6,5 +6,5 @@ ms-vcpp-2013-redist_x86:
     uninstaller: 'http://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe'
     uninstall_flags: '/uninstall /quiet /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ms-vcpp-2015-redist_x64.sls
+++ b/ms-vcpp-2015-redist_x64.sls
@@ -6,7 +6,7 @@ ms-vcpp-2015-redist_x64:
     uninstaller: 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe'
     uninstall_flags: '/uninstall /quiet /norestart & MsiExec.exe /qn /X{0D3E9E15-DE7A-300B-96F1-B4AF12B96488} /norestart & MsiExec.exe /qn /X{BC958BD2-5DAC-3862-BB1A-C1BE0790438D} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # Microsoft Visual C++ 2015 x64 Minimum Runtime - 14.0.23026 {0D3E9E15-DE7A-300B-96F1-B4AF12B96488}
     # Microsoft Visual C++ 2015 x64 Additional Runtime - 14.0.23026 {BC958BD2-5DAC-3862-BB1A-C1BE0790438D}

--- a/ms-vcpp-2015-redist_x86.sls
+++ b/ms-vcpp-2015-redist_x86.sls
@@ -6,7 +6,7 @@ ms-vcpp-2015-redist_x86:
     uninstaller: 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe'
     uninstall_flags: '/uninstall /quiet /norestart & MsiExec.exe /qn /X{A2563E55-3BEC-3828-8D67-E5E8B9E8B675} /norestart & MsiExec.exe /qn /X{BE960C1C-7BAD-3DE6-8B1A-2616FE532845} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # Microsoft Visual C++ 2015 x86 Minimum Runtime - 14.0.23026 {A2563E55-3BEC-3828-8D67-E5E8B9E8B675}
     # Microsoft Visual C++ 2015 x86 Additional Runtime - 14.0.23026 {BE960C1C-7BAD-3DE6-8B1A-2616FE532845}

--- a/mysql-essential.sls
+++ b/mysql-essential.sls
@@ -11,5 +11,5 @@ mysql-essential:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/mysql-installer-community.sls
+++ b/mysql-installer-community.sls
@@ -6,7 +6,7 @@ mysql-installer-community:
     uninstaller: 'http://cdn.mysql.com/Downloads/MySQLInstaller/mysql-installer-community-5.6.23.0.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 #
 # Read for MySQL Server 5.6.23.0 Community installation instructions:

--- a/nmap.sls
+++ b/nmap.sls
@@ -12,5 +12,5 @@ nmap:
     uninstaller: '{{ PROGRAM_FILES }}\Nmap\uninstall.exe"'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/npp.sls
+++ b/npp.sls
@@ -13,6 +13,6 @@ npp:
     uninstaller: '{{ PROGRAM_FILES }}\Notepad++\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
  {% endfor %}

--- a/nsclient.sls
+++ b/nsclient.sls
@@ -12,7 +12,7 @@ nsclient:
     install_flags: '/quiet'
     uninstall_flags: '/quiet'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.4.3.88':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -27,7 +27,7 @@ nsclient:
     install_flags: '/quiet'
     uninstall_flags: '/quiet'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.3.9.328':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -42,5 +42,5 @@ nsclient:
     install_flags: '/quiet'
     uninstall_flags: '/quiet'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/nsis.sls
+++ b/nsis.sls
@@ -10,7 +10,7 @@ nsis:
     {% endif %}
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.0b1':
     full_name: 'Nullsoft Install System'
@@ -23,7 +23,7 @@ nsis:
     {% endif %}
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.46':
     full_name: 'Nullsoft Install System'
@@ -36,5 +36,5 @@ nsis:
     {% endif %}
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/nxlog.sls
+++ b/nxlog.sls
@@ -6,7 +6,7 @@ nxlog:
     uninstaller: 'http://nxlog.org/system/files/products/files/1/nxlog-ce-2.9.1504.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.8.1248':
     full_name:  'NXLOG-CE'
@@ -15,7 +15,7 @@ nxlog:
     uninstaller: 'http://heanet.dl.sourceforge.net/project/nxlog-ce/nxlog-ce-2.8.1248.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.5.1089':
     full_name:  'NXLOG-CE'
@@ -24,5 +24,5 @@ nxlog:
     uninstaller: 'http://downloads.sourceforge.net/project/nxlog-ce/nxlog-ce-2.5.1089.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/openlp.sls
+++ b/openlp.sls
@@ -13,7 +13,7 @@ openlp:
     uninstaller: '{{ PROGRAM_FILES }}\OpenLP\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   Not Found:
     full_name: 'OpenLP 2.0.5'
@@ -22,5 +22,5 @@ openlp:
     uninstaller: '{{ PROGRAM_FILES }}\OpenLP\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/openoffice.sls
+++ b/openoffice.sls
@@ -6,7 +6,7 @@ openoffice:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {E6AD67BB-1C33-4AB3-A387-E0D48137AB70} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False 
   '4.1.1': 
     full_name: 'OpenOffice 4.1.1'
@@ -15,7 +15,7 @@ openoffice:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {9395F41D-0F80-432E-9A59-B8E477E7E163} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 #
 # for other languages replace the two occurrences of 'en-US' 

--- a/openvpn.sls
+++ b/openvpn.sls
@@ -12,7 +12,7 @@ openvpn:
     uninstaller: '%ProgramFiles%\OpenVPN\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.3.6':
     full_name: 'OpenVPN 2.3.6-I601'
@@ -25,7 +25,7 @@ openvpn:
     uninstaller: '%ProgramFiles%\OpenVPN\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 #
 # https://chocolatey.org/packages/openvpn

--- a/ossec-agent.sls
+++ b/ossec-agent.sls
@@ -12,6 +12,6 @@ ossec-agent:
     uninstaller: '{{ PROGRAM_FILES }}\ossec-agent\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # The official download page for the OSSEC agent is http://www.ossec.net/?page_id=19

--- a/passware-kit-agent.sls
+++ b/passware-kit-agent.sls
@@ -6,5 +6,5 @@ passware-kit-agent:
     uninstaller: 'http://www.lostpassword.com/downloads/passware-kit-agent-64bit.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/passware-kit-forensic.sls
+++ b/passware-kit-forensic.sls
@@ -6,5 +6,5 @@ passware-kit-forensic:
     uninstaller: 'salt://win/repo-ng/passware-kit-forensic-13.1.7657/passware-kit-forensic-64bit.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/patchmypc-free.sls
+++ b/patchmypc-free.sls
@@ -13,5 +13,5 @@ patchmypc-free:
                      del /q /f "%SystemRoot%"\PatchMyPC.exe &
                      exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/pdf24creator.sls
+++ b/pdf24creator.sls
@@ -7,7 +7,7 @@ pdf24creator:
     uninstaller: 'http://en.pdf24.org/products/pdf-creator/download/pdf24-creator-{{ version }}.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}
 # Source: http://en.pdf24.org/

--- a/pdfcreator.sls
+++ b/pdfcreator.sls
@@ -12,7 +12,7 @@ pdfcreator:
     uninstaller: '{{ PROGRAM_FILES }}\PDFCreator\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US    
+    locale: {{grains['locale_info']['defaultlanguage']}}    
     reboot: False
   '1.7.2':
     full_name: 'PDFCreator'
@@ -21,5 +21,5 @@ pdfcreator:
     uninstaller: '{{ PROGRAM_FILES }}\PDFCreator\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US    
+    locale: {{grains['locale_info']['defaultlanguage']}}    
     reboot: False

--- a/peazip.sls
+++ b/peazip.sls
@@ -11,5 +11,5 @@ peazip:
     uninstaller: '%ProgramFiles%\PeaZip\unins000.exe'
     uninstall_flags: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/pgina.sls
+++ b/pgina.sls
@@ -4,5 +4,5 @@ pgina:
     installer: 'https://github.com/pgina/pgina/releases/download/v3.1.8.0/pGinaSetup-3.1.8.0.exe'
     install_flags: '/silent '
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/pidgin.sls
+++ b/pidgin.sls
@@ -13,6 +13,6 @@ pidgin:
     uninstaller: '{{ PROGRAM_FILES }}\Pidgin\pidgin-uninst.exe' 
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/postgresql.sls
+++ b/postgresql.sls
@@ -9,7 +9,7 @@ postgresql:
     install_flags: ' --unattendedmodeui minimal --mode unattended --superpassword postgres'
     uninstaller: '%ProgramFiles%\PostgreSQL\9.5\uninstall-postgresql.exe'
     uninstall_flags: ' --mode unattended'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     msiexec: False
     reboot: False
   '9.4':
@@ -22,7 +22,7 @@ postgresql:
     install_flags: ' --unattendedmodeui minimal --mode unattended --superpassword postgres'
     uninstaller: '%ProgramFiles%\PostgreSQL\9.4\uninstall-postgresql.exe'
     uninstall_flags: ' --mode unattended'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     msiexec: False
     reboot: False
   '9.3':
@@ -35,6 +35,6 @@ postgresql:
     install_flags: ' --unattendedmodeui minimal --mode unattended --superpassword postgres'
     uninstaller: '%ProgramFiles%\PostgreSQL\9.3\uninstall-postgresql.exe'
     uninstall_flags: ' --mode unattended'
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     msiexec: False
     reboot: False

--- a/putty.sls
+++ b/putty.sls
@@ -13,6 +13,6 @@ putty:
     uninstaller: '{{ PROGRAM_FILES }}\PuTTY\unins000.exe'
     uninstall_flags: '/SP- /silent /verysilent /suppressmsgboxes /norestart /UNINSTMODE'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/python2_x64.sls
+++ b/python2_x64.sls
@@ -6,7 +6,7 @@ python2_x64:
     uninstaller: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.9150':
     full_name: 'Python 2.7.9 (64-bit)'
@@ -15,7 +15,7 @@ python2_x64:
     uninstaller: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.8150':
     full_name: 'Python 2.7.8 (64-bit)'
@@ -24,7 +24,7 @@ python2_x64:
     uninstaller: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.7150':
     full_name: 'Python 2.7.7 (64-bit)'
@@ -33,7 +33,7 @@ python2_x64:
     uninstaller: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.6150':
     full_name: 'Python 2.7.6 (64-bit)'
@@ -42,5 +42,5 @@ python2_x64:
     uninstaller: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/python2_x86.sls
+++ b/python2_x86.sls
@@ -6,7 +6,7 @@ python2_x86:
     uninstaller: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.9150':
     full_name: 'Python 2.7.9'
@@ -15,7 +15,7 @@ python2_x86:
     uninstaller: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.8150':
     full_name: 'Python 2.7.8'
@@ -24,7 +24,7 @@ python2_x86:
     uninstaller: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.7150':
     full_name: 'Python 2.7.7'
@@ -33,7 +33,7 @@ python2_x86:
     uninstaller: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.7.6150':
     full_name: 'Python 2.7.6'
@@ -42,5 +42,5 @@ python2_x86:
     uninstaller: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/python3_x64.sls
+++ b/python3_x64.sls
@@ -6,7 +6,7 @@ python3_x64:
     uninstaller: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.4.2150':
     full_name: 'Python 3.4.2 (64-bit)'
@@ -15,7 +15,7 @@ python3_x64:
     uninstaller: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.4.1150':
     full_name: 'Python 3.4.1 (64-bit)'
@@ -24,7 +24,7 @@ python3_x64:
     uninstaller: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.3.3150':
     full_name: 'Python 3.3.3 (64-bit)'
@@ -33,5 +33,5 @@ python3_x64:
     uninstaller: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/python3_x86.sls
+++ b/python3_x86.sls
@@ -6,7 +6,7 @@ python3_x86:
     uninstaller: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.4.2150':
     full_name: 'Python 3.4.2'
@@ -15,7 +15,7 @@ python3_x86:
     uninstaller: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.4.1150':
     full_name: 'Python 3.4.1'
@@ -24,7 +24,7 @@ python3_x86:
     uninstaller: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.3.3150':
     full_name: 'Python 3.3.3'
@@ -33,5 +33,5 @@ python3_x86:
     uninstaller: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/quicktime.sls
+++ b/quicktime.sls
@@ -19,7 +19,7 @@ quicktime:
     install_flags: '/quiet /qn /norestart'
     uninstaller: 'msiexec.exe'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
     # the above uninstalls:
     # Apple Software Update v. 2.1.4.131 {FFD1F7F1-1AC9-4BC4-A908-0686D635ABAF}

--- a/rakudo-star_x86.sls
+++ b/rakudo-star_x86.sls
@@ -6,5 +6,5 @@ rakudo-star_x86:
     uninstaller: 'http://rakudo.org/downloads/star/rakudo-star-2016.01-x86 (no JIT).msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/rdcman.sls
+++ b/rdcman.sls
@@ -6,7 +6,7 @@ rdcman:
     uninstaller: 'http://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.2.0423':
     full_name:  'Remote Desktop Connection Manager'
@@ -15,5 +15,5 @@ rdcman:
     uninstaller: 'http://download.microsoft.com/download/5/2/8/5282718D-87FE-4A4F-9226-789ACF368DB1/RDCMan.msi'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/realvnc.sls
+++ b/realvnc.sls
@@ -6,7 +6,7 @@ realvnc:
     uninstaller: '{AAE140B3-14D5-4AF9-A4AF-1628250A8EF1}'
     uninstall_flags: '/qn /norestart  & msiexec.exe /qn /x {FF0D75AD-1856-4170-95CE-556CC3B0E36C} /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.0.5':
     full_name:  'VNC Server 5.0.5'
@@ -15,5 +15,5 @@ realvnc:
     uninstaller: '%PROGRAMFILES%\RealVNC\VNC Server\unins000.exe'
     uninstall_flags: '/sp- /verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/rubyinstaller_x64.sls
+++ b/rubyinstaller_x64.sls
@@ -7,6 +7,6 @@ rubyinstaller_x64:
     uninstaller: 'C:\Ruby{{ dsk_version }}-x64\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/rubyinstaller_x86.sls
+++ b/rubyinstaller_x86.sls
@@ -7,6 +7,6 @@ rubyinstaller_x86:
     uninstaller: 'C:\Ruby{{ dsk_version }}\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -16,6 +16,6 @@ saltstack.minion:
     refresh: true
     msiexec: False
     use_scheduler: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/sandboxie.sls
+++ b/sandboxie.sls
@@ -12,5 +12,5 @@ sandboxie:
     install_flags: '/S'
     uninstall_flags: '/remove'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/secunia.psi.sls
+++ b/secunia.psi.sls
@@ -12,5 +12,5 @@ secunia.psi:
     uninstaller: '{{ PROGRAM_FILES }}\Secunia\PSI\uninstall.exe'
     uninstall_flags: '/S'    
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/sensu.sls
+++ b/sensu.sls
@@ -6,5 +6,5 @@ sensu:
     uninstaller: 'http://repositories.sensuapp.org/msi/sensu-0.21.0-1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/sharpdevelop.sls
+++ b/sharpdevelop.sls
@@ -6,7 +6,7 @@ sharpdevelop:
     uninstaller: 'http://netassist.dl.sourceforge.net/project/sharpdevelop/SharpDevelop%205.x/5.1%20RC/SharpDevelop_5.1.0.5134_RC_Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '4.4.9749':
     full_name: 'SharpDevelop 4.4'
@@ -15,7 +15,7 @@ sharpdevelop:
     uninstaller: 'http://freefr.dl.sourceforge.net/project/sharpdevelop/SharpDevelop%204.x/4.4/SharpDevelop_4.4.2.9749_Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '3.2.6466':
     full_name: 'SharpDevelop 3.2.1'
@@ -24,7 +24,7 @@ sharpdevelop:
     uninstaller: 'http://skylink.dl.sourceforge.net/project/sharpdevelop/SharpDevelop%203.x/3.2/SharpDevelop_3.2.1.6466_Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '2.2.2648':
     full_name: 'SharpDevelop 2.2'
@@ -33,5 +33,5 @@ sharpdevelop:
     uninstaller: 'http://freefr.dl.sourceforge.net/project/sharpdevelop/SharpDevelop%202.x/2.2.1/SharpDevelop_2.2.1.2648_Setup.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/silverlight.sls
+++ b/silverlight.sls
@@ -6,5 +6,5 @@ silverlight:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /X{89F4137D-6C26-4A84-BDB8-2E5A4BB71E00} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/skitch.sls
+++ b/skitch.sls
@@ -12,5 +12,5 @@ skitch:
     uninstaller: '{{ PROGRAM_FILES }}\Evernote\Skitch\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/skype-msi.sls
+++ b/skype-msi.sls
@@ -6,7 +6,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.18.0.112.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.18.111':
     full_name: 'Skype™ 7.18'
@@ -15,7 +15,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.18.0.111.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.18.103':
     full_name: 'Skype™ 7.18'
@@ -24,7 +24,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.18.0.103.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.17.106':
     full_name: 'Skype™ 7.17'
@@ -33,7 +33,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.17.0.106.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.8.102':
     full_name: 'Skype™ 7.8'
@@ -42,7 +42,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.8.0.102.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.7.102':
     full_name: 'Skype™ 7.7'
@@ -51,7 +51,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.7.0.102.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.1.0.105':
     full_name: 'Skype™ 7.1'
@@ -60,7 +60,7 @@ skype-msi:
     uninstaller: 'http://download.skype.com/msi/SkypeSetup_7.1.0.105.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
 # you can always get latest msi from:
 # http://www.skype.com/go/getskype-msi (but version number keeps increasing)

--- a/slack.sls
+++ b/slack.sls
@@ -6,5 +6,5 @@ slack:
     uninstaller: '%LocalAppData%/slack/Update.exe'
     uninstall_flags: '--uninstall -s' 
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/smartmontools.sls
+++ b/smartmontools.sls
@@ -12,5 +12,5 @@ smartmontools:
     uninstaller: '{{ PROGRAM_FILES }}\smartmontools\uninst-smartmontools.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/smssender.sls
+++ b/smssender.sls
@@ -7,5 +7,5 @@ smssender:
     uninstaller: 'http://download.microsoft.com/download/8/f/d/8fd4e1cd-b2d7-4e23-9c5b-54b76fa222b9/smssender.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/snmptools.sls
+++ b/snmptools.sls
@@ -12,5 +12,5 @@ snmptools:
     uninstaller: '{{ PROGRAM_FILES }}\SnmpTools\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/software-informer.sls
+++ b/software-informer.sls
@@ -13,5 +13,5 @@ software-informer:
     uninstaller: '{{ PROGRAM_FILES }}\Software Informer\unins000.exe'
     uninstall_flags: '/SP- /VERYSILENT /NORESTART /SUPPRESSMSGBOXES'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/sourcetree.sls
+++ b/sourcetree.sls
@@ -6,5 +6,5 @@ sourcetree:
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {9FFB4428-D676-449F-B173-52C0E9FF1179} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/spybot.sls
+++ b/spybot.sls
@@ -13,7 +13,7 @@ spybot:
     uninstaller: '{{ PROGRAM_FILES }}\Spybot - Search & Destroy 2\unins000.exe'
     uninstall_flags: '/VERYSILENT /SuppressMsgGBoxes /NoRestart /SP-'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 # alternative download URLs
 # http://www.spybotupdates.biz/files/spybot-2.4.exe

--- a/stellarium.sls
+++ b/stellarium.sls
@@ -12,7 +12,7 @@ stellarium:
     uninstaller: '{{ PROGRAM_FILES }}\Stellarium\unins000.exe'
     uninstall_flags: '/silent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '0.13.2':
     full_name: 'Stellarium 0.13.2'
@@ -25,5 +25,5 @@ stellarium:
     uninstaller: '{{ PROGRAM_FILES }}\Stellarium\unins000.exe'
     uninstall_flags: '/silent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/strawberryperl_x64.sls
+++ b/strawberryperl_x64.sls
@@ -7,6 +7,6 @@ strawberryperl_x64:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/strawberryperl_x86.sls
+++ b/strawberryperl_x86.sls
@@ -7,6 +7,6 @@ strawberryperl_x86:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/stunnel.sls
+++ b/stunnel.sls
@@ -12,5 +12,5 @@ stunnel:
     uninstaller: '{{ PROGRAM_FILES }}\stunnel\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/subinacl.sls
+++ b/subinacl.sls
@@ -6,5 +6,5 @@ subinacl:
     uninstaller: '{D3EE034D-5B92-4A55-AA02-2E6D0A6A96EE}'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/sums.sls
+++ b/sums.sls
@@ -23,5 +23,5 @@ sums:
                       del /q /f %SystemRoot%\sha512sum.exe & 
                       exit 0'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/svn.sls
+++ b/svn.sls
@@ -6,7 +6,7 @@ svn:
     uninstaller: 'http://sourceforge.net/projects/win32svn/files/1.8.13/Setup-Subversion-1.8.13.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '1.8.11':
     full_name: 'Subversion'
@@ -15,5 +15,5 @@ svn:
     uninstaller: 'http://sourceforge.net/projects/win32svn/files/1.8.11/Setup-Subversion-1.8.11.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/teamviewer.sls
+++ b/teamviewer.sls
@@ -12,5 +12,5 @@ teamviewer:
     uninstaller: '{{ PROGRAM_FILES }}\TeamViewer\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/teracopy.sls
+++ b/teracopy.sls
@@ -15,5 +15,5 @@ teracopy:
     uninstaller: '{{ PROGRAM_FILES }}\TeraCopy\unins000.exe'
     uninstall_flags: '/SP- /verysilent /suppressmsgboxes /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/thunderbird.sls
+++ b/thunderbird.sls
@@ -13,6 +13,6 @@ thunderbird:
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Thunderbird\uninstall\helper.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/tightvnc.sls
+++ b/tightvnc.sls
@@ -11,5 +11,5 @@ tightvnc:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/tortoise-bzr.sls
+++ b/tortoise-bzr.sls
@@ -13,5 +13,5 @@ tortoise-bzr:
     uninstaller: '{{ PROGRAM_FILES }}\Bazaar\uninst000.exe'
     uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/tortoise-git.sls
+++ b/tortoise-git.sls
@@ -13,5 +13,5 @@ tortoise-git:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/tortoise-hg.sls
+++ b/tortoise-hg.sls
@@ -13,7 +13,7 @@ tortoise-hg:
     install_flags: '/qn /norestart'    
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False  
   '3.3.0':
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -28,7 +28,7 @@ tortoise-hg:
     install_flags: '/qn /norestart'    
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    
 # Need to download from source site above, so it will append proper aws key credentials
 # place downloaded msi in master's win_repo-ng 

--- a/tortoise-svn.sls
+++ b/tortoise-svn.sls
@@ -13,5 +13,5 @@ tortoise-svn:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/truecrypt.sls
+++ b/truecrypt.sls
@@ -12,5 +12,5 @@ truecrypt:
     uninstaller: '{{ PROGRAM_FILES }}\Truecrypt\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ultradefrag.sls
+++ b/ultradefrag.sls
@@ -12,7 +12,7 @@ ultradefrag:
     uninstaller: '{{ PROGRAM_FILES }}\UltraDefrag\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '6.0.2':
     full_name: 'Ultra Defragmenter 6.0.2'
@@ -25,5 +25,5 @@ ultradefrag:
     uninstaller: '{{ PROGRAM_FILES }}\UltraDefrag\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/ultravnc.sls
+++ b/ultravnc.sls
@@ -11,5 +11,5 @@ ultravnc:
     uninstaller: '{{ PROGRAM_FILES }}\uvnc bvba\UltraVnc\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/urlrewrite.sls
+++ b/urlrewrite.sls
@@ -13,7 +13,7 @@ urlrewrite:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '7.1.0490.43':
     full_name: 'Microsoft URL Rewrite Module 1.1 for IIS 7'
@@ -27,5 +27,5 @@ urlrewrite:
     install_flags: '/quiet /norestart'
     uninstall_flags: '/quiet /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/vagrant.sls
+++ b/vagrant.sls
@@ -7,6 +7,6 @@ vagrant:
     uninstaller: 'https://releases.hashicorp.com/vagrant/{{ version }}/vagrant_{{ version }}.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/vcforpython27.sls
+++ b/vcforpython27.sls
@@ -6,5 +6,5 @@ vcforpython27:
     uninstaller: 'http://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/vcredist2010_x64.sls
+++ b/vcredist2010_x64.sls
@@ -6,5 +6,5 @@ vcredist2010_x64:
     uninstaller: 'http://download.microsoft.com/download/A/8/0/A80747C3-41BD-45DF-B505-E9710D2744E0/vcredist_x64.exe'
     uninstall_flags: '/uninstall /norestart /q'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/vcredist2010_x86.sls
+++ b/vcredist2010_x86.sls
@@ -6,5 +6,5 @@ vcredist2010_x86:
     uninstaller: 'http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe'
     uninstall_flags: '/uninstall /norestart /q'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/virtualbox.sls
+++ b/virtualbox.sls
@@ -6,5 +6,5 @@ virtualbox:
     uninstaller: 'msiexec.exe'
     uninstaller_flags: '/qn /x {E8BB81BC-E67C-4750-84EE-128DA5A7ADA5} /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/vlc.sls
+++ b/vlc.sls
@@ -12,5 +12,5 @@ vlc:
     uninstaller: '{{ PROGRAM_FILES }}\VideoLAN\VLC\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/vsee.sls
+++ b/vsee.sls
@@ -6,5 +6,5 @@ vsee:
     uninstaller: '%AppData%\VSeeInstall\vseeUninstall.exe'
     uninstall_flags: '-no_confirm'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/wamp-server-3.sls
+++ b/wamp-server-3.sls
@@ -13,5 +13,5 @@ wamp-server-3:
     {% endif %}
     install_flags: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/wamp-server.sls
+++ b/wamp-server.sls
@@ -10,5 +10,5 @@ wamp-server:
     uninstaller: 'c:\wamp\uninstall_services.bat'
     uninstall_flags: '& c:\wamp\unins000.exe /S /VERYSILENT'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/wamp-stack.sls
+++ b/wamp-stack.sls
@@ -6,7 +6,7 @@ wamp-stack:
     uninstaller: 'c:\Bitnami\wampstack-5.5.30-0\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.4.36.0':
     full_name: 'Bitnami WAMP Stack 5.4.36'
@@ -15,5 +15,5 @@ wamp-stack:
     uninstaller: 'c:\Bitnami\wampstack-5.4.36-0\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/webdeploy.sls
+++ b/webdeploy.sls
@@ -11,5 +11,5 @@ webdeploy:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/webplatforminstaller.sls
+++ b/webplatforminstaller.sls
@@ -11,5 +11,5 @@ webplatforminstaller:
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True    
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False    

--- a/win-app-manager.sls
+++ b/win-app-manager.sls
@@ -12,5 +12,5 @@ win-app-manager:
     uninstaller: '{{ PROGRAM_FILES }}\WinApp Manager\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/windirstat.sls
+++ b/windirstat.sls
@@ -12,5 +12,5 @@ windirstat:
     uninstaller: '{{ PROGRAM_FILES }}\WinDirStat\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/winhttpcertcfg.sls
+++ b/winhttpcertcfg.sls
@@ -6,5 +6,5 @@ winhttpcertcfg:
     uninstaller: 'http://download.microsoft.com/download/4/5/b/45bab62d-cdd8-42c7-85d0-0275b96db2c5/winhttpcertcfg.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/winmerge.sls
+++ b/winmerge.sls
@@ -11,5 +11,5 @@ winmerge:
     uninstaller: '{{ PROGRAM_FILES }}\WinMerge\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/winpcap.sls
+++ b/winpcap.sls
@@ -6,5 +6,5 @@ winpcap:
     uninstaller: '%PROGRAMFILES%\WinPcap\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/winscp.sls
+++ b/winscp.sls
@@ -12,6 +12,6 @@ winscp:
     uninstaller: '{{ PROGRAM_FILES }}\WinSCP\unins000.exe'
     uninstall_flags: '/verysilent'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/wireshark-devel.sls
+++ b/wireshark-devel.sls
@@ -13,5 +13,5 @@ wireshark-devel:
     uninstaller: '{{ PROGRAM_FILES }}\Wireshark\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/wireshark.sls
+++ b/wireshark.sls
@@ -14,6 +14,6 @@ wireshark:
     uninstaller: '{{ PROGRAM_FILES }}\Wireshark\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   {% endfor %}

--- a/wscc.sls
+++ b/wscc.sls
@@ -11,5 +11,5 @@ wscc:
     {% endif %}
     uninstall_flags: '/SILENT /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/xampp.sls
+++ b/xampp.sls
@@ -6,7 +6,7 @@ xampp:
     uninstaller: 'c:\xampp\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.6.15.1':
     full_name: 'XAMPP 5.6.15'
@@ -15,7 +15,7 @@ xampp:
     uninstaller: 'c:\xampp\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
   '5.6.3.0':
     full_name: 'XAMPP 5.6.3'
@@ -24,5 +24,5 @@ xampp:
     uninstaller: 'c:\xampp\uninstall.exe'
     uninstall_flags: '--mode unattended'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False   

--- a/xming.sls
+++ b/xming.sls
@@ -13,5 +13,5 @@ xming:
     uninstaller: '{{ PROGRAM_FILES }}\Xming\unins000.exe'
     uninstall_flags: '/SP- /verysilent /norestart'
     msiexec: False
-    locale: en_US
+    locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/zeal.sls
+++ b/zeal.sls
@@ -12,7 +12,7 @@ zeal:
     installer: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
     install_flags: '/quiet'
     uninstaller: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
-    uninstall_flags: '/uninstall /quiet'
+    uninstall_flags: '/quiet'
     msiexec: True
     locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False

--- a/zeal.sls
+++ b/zeal.sls
@@ -6,9 +6,9 @@ zeal:
     {% set PROGRAM_FILES = "%ProgramFiles%" %}
     {% set arch = "win32" %}
   {% endif %}
-  {% for version in '0.2.1' %}
+  {% set version = '0.2.1' %}
   '{{ version }}':
-    full_name: 'Zeal {{ version }} x86 {{grains['locale_info']['defaultlanguage']}})'
+    full_name: 'Zeal'
     installer: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
     install_flags: '/quiet'
     uninstaller: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
@@ -16,5 +16,4 @@ zeal:
     msiexec: True
     locale: {{grains['locale_info']['defaultlanguage']}}
     reboot: False
-  {% endfor %}
 

--- a/zeal.sls
+++ b/zeal.sls
@@ -1,0 +1,20 @@
+zeal:
+  {% if grains['cpuarch'] == 'AMD64' %}
+    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
+    {% set arch = "win64" %}
+  {% else %}
+    {% set PROGRAM_FILES = "%ProgramFiles%" %}
+    {% set arch = "win32" %}
+  {% endif %}
+  {% for version in '0.2.1' %}
+  '{{ version }}':
+    full_name: 'Zeal {{ version }} x86 {{grains['locale_info']['defaultlanguage']}})'
+    installer: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
+    install_flags: '/quiet'
+    uninstaller: 'https://bintray.com/artifact/download/zealdocs/windows/zeal-{{version}}-windows-x86.msi'
+    uninstall_flags: '/uninstall /quiet'
+    msiexec: True
+    locale: {{grains['locale_info']['defaultlanguage']}}
+    reboot: False
+  {% endfor %}
+


### PR DESCRIPTION
I think this should make it possible for both AMD64 and x86 users to install firefox in their 
respective architecture. 

Here's the result using Windows Server 2008 in AMD64:

(I can test it with Windows Seven Pro AMD64 later today). 
I have no 32 bit windows installation. 

~~~
root@my-salt:~# salt -C 'G@os:Windows' pkg.install firefox
my-windows-server-2008:
    ----------
    Mozilla Firefox 45.0 (x64 en-US):
        ----------
        new:
            45.0
        old:
    Mozilla Maintenance Service:
        ----------
        new:
            45.0
        old:
    _comment:
        Registry not updated.
~~~

