### PR TITLE
Create initial SSC Serv Free 3.6.1

### DIFF
--- a/sscserv-free.sls
+++ b/sscserv-free.sls
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+{% if grains['cpuarch'] == 'AMD64' %}
+  {% set PLATFORM = 'x86-64' %}
+{% else %}
+  {% set PLATFORM = 'x86' %}
+{% endif %}
+sscserv-free:
+  {% for version in '3.6.1', '3.5.0' %}
+  '{{ version }}':
+    full_name: 'SSC Serv {{ version }} Free Edition'
+    installer: 'http://ssc-serv.com/files/SSC%20Serv%20Setup%20{{ version }}%20{{ PLATFORM }}%20Free%20Edition.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SSC Serv\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False
+  {% endfor %}


### PR DESCRIPTION
SSC Serv is a service for Microsoft Windows, which collects system statistics and submits them to a central statistics server. It is similar to and compatible with collectd, a free and open-sourced solution for UNIX systems.

https://ssc-serv.com/features.shtml

Tested install on Windows 2012r2 with salt-minion 2016.3.0.