### PR TITLE
Update eea.sls

### DIFF
--- a/eea.sls
+++ b/eea.sls
@@ -3,7 +3,7 @@ eea:
     full_name: 'ESET Endpoint Antivirus'
     {% if grains['cpuarch'] == 'AMD64' %}
     installer: 'http://download.eset.com/download/win/eea/eea_nt64_enu.msi'
-    uninstaller: 'http://download.eset.com/download/win/eea/eea_nt64_enu.msi
+    uninstaller: 'http://download.eset.com/download/win/eea/eea_nt64_enu.msi'
     {% elif grains['cpuarch'] == 'x86' %}
     installer: 'http://download.eset.com/download/win/eea/eea_nt32_enu.msi'
     uninstaller: 'http://download.eset.com/download/win/eea/eea_nt32_enu.msi'


### PR DESCRIPTION
Running win.pkg_refresh is failing, seemingly because of a syntax error in this file:

2016-04-15 17:11:37,679 [salt.template    ][PROFILE ][1084] Time (in seconds) to render 'c:\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng_git\eea.sls' using 'jinja' renderer: 0.0
2016-04-15 17:11:37,695 [salt.template    ][DEBUG   ][1084] Rendered data from file: c:\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng_git\eea.sls:
eea:
  '6.3.2016.0':
    full_name: 'ESET Endpoint Antivirus'
    
    installer: 'http://download.eset.com/download/win/eea/eea_nt64_enu.msi'
    uninstaller: 'http://download.eset.com/download/win/eea/eea_nt64_enu.msi
    
    install_flags: '/qn ALLUSERS=1 /norestart'
    uninstall_flags: '/qn /norestart'
    msiexec: True
    locale: en_US
    reboot: False
  '6.2.2021.0':
    full_name: 'ESET Endpoint Antivirus'
    
    installer: 'salt://win/repo-ng/eea/v6/eea_nt64_enu.msi'
    uninstaller: 'salt://win/repo-ng/eea/v6/eea_nt64_enu.msi'
    
    install_flags: '/qn ALLUSERS=1 /norestart'
    uninstall_flags: '/qn /norestart'
    msiexec: True
    locale: en_US
    reboot: False
  '5.0.2254.0':
    full_name: 'ESET Endpoint Antivirus'
    
    installer: 'salt://win/repo-ng/eea/v5/eea_nt64_enu.msi'
    uninstaller: 'salt://win/repo-ng/eea/v5/eea_nt64_enu.msi'
    
    install_flags: '/qn ALLUSERS=1 /norestart'
    uninstall_flags: '/qn /norestart'
    msiexec: True
    locale: en_US
    reboot: False
2016-04-15 17:11:37,695 [salt.log.setup   ][ERROR   ][1084] An un-handled exception was caught by salt's global exception handler:
ParserError: while parsing a block mapping
  in "<unicode string>", line 3, column 5:
        full_name: 'ESET Endpoint Antivirus'
        ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 8, column 21:
        install_flags: '/qn ALLUSERS=1 /norestart'
                        ^
Traceback (most recent call last):
  File "C:\salt\bin\Scripts\salt-call", line 11, in <module>
    salt_call()
  File "C:\salt\bin\lib\site-packages\salt\scripts.py", line 335, in salt_call
    client.run()
  File "C:\salt\bin\lib\site-packages\salt\cli\call.py", line 53, in run
    caller.run()
  File "C:\salt\bin\lib\site-packages\salt\cli\caller.py", line 133, in run
    ret = self.call()
  File "C:\salt\bin\lib\site-packages\salt\cli\caller.py", line 196, in call
    ret['return'] = func(*args, **kwargs)
  File "C:\salt\bin\lib\site-packages\salt\modules\win_pkg.py", line 408, in refresh_db
    genrepo(saltenv=saltenv)
  File "C:\salt\bin\lib\site-packages\salt\modules\win_pkg.py", line 454, in genrepo
    __opts__['renderer'])
  File "C:\salt\bin\lib\site-packages\salt\template.py", line 95, in compile_template
    ret = render(input_data, saltenv, sls, **render_kwargs)
  File "C:\salt\bin\lib\site-packages\salt\renderers\yaml.py", line 51, in render
    data = load(yaml_data, Loader=get_yaml_loader(argline))
  File "C:\salt\bin\lib\site-packages\yaml\__init__.py", line 71, in load
    return loader.get_single_data()
  File "C:\salt\bin\lib\site-packages\yaml\constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "C:\salt\bin\lib\site-packages\yaml\composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "C:\salt\bin\lib\site-packages\yaml\parser.py", line 98, in check_event
    self.current_event = self.state()
  File "C:\salt\bin\lib\site-packages\yaml\parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
ParserError: while parsing a block mapping
  in "<unicode string>", line 3, column 5:
        full_name: 'ESET Endpoint Antivirus'
        ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 8, column 21:
        install_flags: '/qn ALLUSERS=1 /norestart'
                        ^
I noticed that line 6 is missing a closing quote, and added it.