### PR TITLE
New formula for adobereader-dc which is adapted to the new version numbers

### DIFF
--- a/adobereader-dc-classic.sls
+++ b/adobereader-dc-classic.sls
@@ -1,0 +1,16 @@
+# to understand what is meant by "classic" see 
+# http://www.adobe.com/devnet-docs/acrobatetk/tools/AdminGuide/whatsnewdc.html
+
+adobereader-dc-classic:
+  {% for version in ['15.010.20060'] %}
+  {% set versionNoDots = version | replace(".","") %}
+  '{{ version }}':
+    full_name: 'Adobe Acrobat Reader DC'
+    installer: 'https://ardownload2.adobe.com/pub/adobe/reader/win/AcrobatDC/{{ versionNoDots }}/AcroRdrDC{{ versionNoDots }}_en_US.exe'
+    install_flags: '/msi EULA_ACCEPT=YES ALLUSERS=1 REMOVE_PREVIOUS=YES /qn'
+    uninstaller: 'msiexec.exe'
+    uninstall_flags: '/qn /x {AC76BA86-7AD7-1033-7B44-AC0F074E4100} /norestart'
+    msiexec: False
+    locale: en_US
+    reboot: False
+  {% endfor %}

--- a/firefox-esr.sls
+++ b/firefox-esr.sls
@@ -7,7 +7,7 @@ firefox-esr:
   {% endif %}
   {% for version in '45.1.0', '45.0.2', '38.7.1', '38.6.1', '38.6.0', '38.5.0', '38.4.0', '38.3.0', '38.2.1' %}
   '{{ version }}':
-    full_name: 'Mozilla Firefox {{ version }} (x86 en-US)'
+    full_name: 'Mozilla Firefox {{ version }} ESR (x86 en-US)'
     installer: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/{{ version }}esr/win32/en-US/Firefox%20Setup%20{{ version }}esr.exe'
     install_flags: '/s'
     uninstaller: '{{ PROGRAM_FILES }}\Mozilla Firefox\uninstall\helper.exe'


### PR DESCRIPTION
WIth the enterprise installer we'ere now getting the "classic" version as ooposed to "continuous", and the version numbers are different so I've made a new sls file.