### PR TITLE
Fix full_name for PostgreSQL

### DIFF
--- a/postgresql.sls
+++ b/postgresql.sls
@@ -1,6 +1,6 @@
 postgresql:
   '9.5':
-    full_name: 'PostgreSQL 9.5'
+    full_name: 'PostgreSQL 9.5 '
     {% if grains['cpuarch'] == 'AMD64' %}
     installer: 'http://get.enterprisedb.com/postgresql/postgresql-9.5.0-1-windows-x64.exe'
     {% else %}
@@ -13,7 +13,7 @@ postgresql:
     msiexec: False
     reboot: False
   '9.4':
-    full_name: 'PostgreSQL 9.4'
+    full_name: 'PostgreSQL 9.4 '
     {% if grains['cpuarch'] == 'AMD64' %}
     installer: 'http://get.enterprisedb.com/postgresql/postgresql-9.4.5-3-windows-x64.exe'
     {% else %}
@@ -26,7 +26,7 @@ postgresql:
     msiexec: False
     reboot: False
   '9.3':
-    full_name: 'PostgreSQL 9.3'
+    full_name: 'PostgreSQL 9.3 '
     {% if grains['cpuarch'] == 'AMD64' %}
     installer: 'http://get.enterprisedb.com/postgresql/postgresql-9.3.10-3-windows-x64.exe'
     {% else %}


### PR DESCRIPTION
Curious, full_name for the PostgreSQL contains a white space in end. Without this fix result of uninstallation will be next:

```
salt win-230416-010535 state.single pkg.removed postgresql
win-230416-010535:
----------
          ID: postgresql
    Function: pkg.removed
      Result: True
     Comment: All specified packages are already absent
     Started: 02:00:58.681000
    Duration: 62.0 ms
     Changes:

Summary for win-230416-010535
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1

```