### PR TITLE
Fix full_name and version strings for Visual C++ redist packages

### DIFF
--- a/ms-vcpp-2010-sp1-mfc-redist_64.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_64.sls
@@ -1,6 +1,6 @@
 ms-vcpp-2010-sp1-mfc-redist_x64:
   '10.0.40219':
-    full_name: 'Microsoft Visual C++ 2010 Redistributable - x64 10.0.40219'
+    full_name: 'Microsoft Visual C++ 2010 Redistributable -  x64 10.0.40219'
     installer: 'http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe'
     install_flags: '/q /norestart'
     uninstaller: 'msiexec.exe'

--- a/ms-vcpp-2010-sp1-mfc-redist_x86.sls
+++ b/ms-vcpp-2010-sp1-mfc-redist_x86.sls
@@ -1,6 +1,6 @@
 ms-vcpp-2010-sp1-mfc-redist_x86:
   '10.0.40219':
-    full_name: 'Microsoft Visual C++ 2010 Redistributable - x86 10.0.40219'
+    full_name: 'Microsoft Visual C++ 2010 Redistributable -  x86 10.0.40219'
     installer: 'http://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe'
     install_flags: '/q /norestart'
     uninstaller: 'msiexec.exe'

--- a/ms-vcpp-2015-redist_x64.sls
+++ b/ms-vcpp-2015-redist_x64.sls
@@ -1,5 +1,5 @@
 ms-vcpp-2015-redist_x64:
-  '14.0.23026':
+  '14.0.23026.0':
     full_name: 'Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.23026'
     installer: 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe'
     install_flags: '/quiet /norestart'

--- a/ms-vcpp-2015-redist_x86.sls
+++ b/ms-vcpp-2015-redist_x86.sls
@@ -1,5 +1,5 @@
 ms-vcpp-2015-redist_x86:
-  '14.0.23026':
+  '14.0.23026.0':
     full_name: 'Microsoft Visual C++ 2015 Redistributable (x86) - 14.0.23026'
     installer: 'http://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe'
     install_flags: '/quiet /norestart'


### PR DESCRIPTION
Adds extra space character for full_name of ms-vcpp-2010-sp1-mfc-redist_x86 and ms-vcpp-2010-sp1-mfc-redist_x64.
Adds missing '.0' to version string of ms-vcpp-2015-redist_x86 and
ms-vcpp-2015-redist_x64.