### PR TITLE
Add clarification to salt-minion definition

### DIFF
--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -1,5 +1,14 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# This software definition will only work in versions of salt newer than
+# 2015.8.2. In verion 2015.8.2 we added the `use_scheduler` option which
+# allowed us to launch the installer using the windows task manager.
+# This option is not available in earlier versions of salt. So, while this
+# software definition will allow you to install versions of salt older than
+# 2015.8.2 you will not be able to use pkg.install to upgrade salt again. You
+# will have to upgrade salt through another means.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 salt-minion:
-  {% for version in '2015.8.8-2', '2015.8.7', '2015.8.5', '2015.8.4', '2015.8.3', '2015.8.1', '2015.8.0-3', '2015.5.10', '2015.5.9', '2015.5.8', '2015.5.6', '2015.5.5', '2015.5.3-2' %}
+  {% for version in '2015.8.8', '2015.8.7', '2015.8.5', '2015.8.4', '2015.8.3', '2015.8.1', '2015.8.0-3', '2015.5.10', '2015.5.9', '2015.5.8', '2015.5.6', '2015.5.5', '2015.5.3-2' %}
   '{{ version }}':
     full_name: 'Salt Minion {{ version }}'
     {% if grains['cpuarch'] == 'AMD64' %}


### PR DESCRIPTION
Added comments explaining the dangers of rolling back to a version of salt that doesn't implement the `use_scheduler` option.

Also, removed the reference to 2015.8.8-2 which was causing some problem with grains not matching the version of salt. There are now two files on repo.saltstack.com for 2015.8.8. One with the -2 for existing software defs and one without for this one and going forward. They are both the same file.