### PR TITLE
Update jre8.sls

### DIFF
--- a/jre8.sls
+++ b/jre8.sls
@@ -1,5 +1,5 @@
 jre8:
-  '8.0.910.14':
+  '8.0.910.15':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Java 8 Update 91 (64-bit)'
     installer: 'salt://win/repo-ng/jre8/jre-8u91-windows-x64.exe'


### PR DESCRIPTION
Bump version to .15 which matches Oracle's latest installer for jre-8u91-windows-x64.exe