### PR TITLE
nmap: Remove '"' in uninstaller line

### DIFF
--- a/nmap.sls
+++ b/nmap.sls
@@ -9,7 +9,7 @@ nmap:
     full_name: 'Nmap 7.01'
     installer: 'http://nmap.org/dist/nmap-7.01-setup.exe'
     install_flags: '/S'
-    uninstaller: '{{ PROGRAM_FILES }}\Nmap\uninstall.exe"'
+    uninstaller: '{{ PROGRAM_FILES }}\Nmap\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
     locale: en_US


### PR DESCRIPTION
Trailing " in uninstaller stops nmap from being able to be removed