### PR TITLE
Add latest to Octopus Tentacle definition

### DIFF
--- a/octopus-tentacle.sls
+++ b/octopus-tentacle.sls
@@ -5,7 +5,17 @@
 {% else %}
   {% set PLATFORM = '' %}
 {% endif %}
+{% set PLATFORM_LATEST = PLATFORM | replace('-x', '') -%}
 octopus-tentacle:
+  'latest':
+    full_name: 'Octopus Deploy Tentacle'
+    installer: 'https://octopus.com/downloads/latest/OctopusTentacle{{ PLATFORM_LATEST }}'
+    install_flags: '/qn ALLUSERS=1 /norestart'
+    uninstaller: 'https://octopus.com/downloads/latest/OctopusTentacle{{ PLATFORM_LATEST }}'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
 {% for version in ('3.3.17', '3.3.16') %}
   '{{ version }}':
     full_name: 'Octopus Deploy Tentacle'


### PR DESCRIPTION
**Changes**

* Updated Octopus Tentacle definition to include latest version via the relevant URI.

**Testing**

* Tested on Windows 2012r2 running salt-minion 2016.3.3.