### PR TITLE
7-zip 16.04 reports 16.04.00.0 as version

### DIFF
--- a/7zip.sls
+++ b/7zip.sls
@@ -1,7 +1,7 @@
 # both 32-bit (x86) AND a 64-bit (AMD64) installer available
 {% set PROGRAM_FILES = "%ProgramFiles%" %}
 7zip:
-  '16.04':
+  '16.04.00.0':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: '7-Zip 16.04 (x64 edition)'
     installer: 'http://d.7-zip.org/a/7z1604-x64.msi'


### PR DESCRIPTION
Hi,

7-zip 16.04 reports 16.04.00.0 as version.
Currently installations succeed, but verification fails.

```
----------
          ID: 7zip
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: 7zip=16.04
     Started: 09:59:43.462000
    Duration: 13100.0 ms
     Changes:
              ----------
              7zip:
                  ----------
                  install status:
                      success

```
![screen shot 2016-10-20 at 10 48 47](https://cloud.githubusercontent.com/assets/300014/19553940/a4c2144a-96b6-11e6-8c56-6259218526d4.png)
