### PR TITLE
Update Putty.sls

### DIFF
--- a/putty.sls
+++ b/putty.sls
@@ -1,6 +1,6 @@
 # just 32-bit x86 installer available
 putty:
-{% for version in '0.68' %}
+{% for version in ['0.68'] %}
   '{{ version }}':
     full_name:  'PuTTY release {{ version }}'
     {% if grains['cpuarch'] == 'AMD64' %}
@@ -16,7 +16,7 @@ putty:
     locale: en_US
     reboot: False
   {% endfor %}
-{% for version in '0.67', '0.66', '0.65', '0.64' %}
+{% for version in ['0.67', '0.66', '0.65', '0.64'] %}
   {% if grains['cpuarch'] == 'AMD64' %}
     {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
   {% else %}

--- a/putty.sls
+++ b/putty.sls
@@ -1,11 +1,27 @@
 # just 32-bit x86 installer available
-{% if grains['cpuarch'] == 'AMD64' %}
-    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
-{% else %}
-    {% set PROGRAM_FILES = "%ProgramFiles%" %}
-{% endif %}
 putty:
-  {% for version in '0.67', '0.66', '0.65', '0.64' %}
+{% for version in '0.68' %}
+  '{{ version }}':
+    full_name:  'PuTTY release {{ version }}'
+    {% if grains['cpuarch'] == 'AMD64' %}
+    installer: 'https://the.earth.li/~sgtatham/putty/{{ version }}/w64/putty-64bit-{{ version }}-installer.msi'
+	uninstaller: 'https://the.earth.li/~sgtatham/putty/{{ version }}/w64/putty-64bit-{{ version }}-installer.msi'
+    {% elif grains['cpuarch'] == 'x86' %}
+    installer: 'https://the.earth.li/~sgtatham/putty/{{ version }}/w32/putty-{{ version }}-installer.msi'
+	uninstaller: 'https://the.earth.li/~sgtatham/putty/{{ version }}/w32/putty-{{ version }}-installer.msi'
+    {% endif %}
+    install_flags: ' /qn '
+    uninstall_flags: ' /qn '
+    msiexec: True
+    locale: en_US
+    reboot: False
+  {% endfor %}
+{% for version in '0.67', '0.66', '0.65', '0.64' %}
+  {% if grains['cpuarch'] == 'AMD64' %}
+    {% set PROGRAM_FILES = "%ProgramFiles(x86)%" %}
+  {% else %}
+    {% set PROGRAM_FILES = "%ProgramFiles%" %}
+  {% endif %}
   '{{ version }}':
     full_name:  'PuTTY release {{ version }}'
     installer: 'http://the.earth.li/~sgtatham/putty/{{ version }}/x86/putty-{{ version }}-installer.exe'


### PR DESCRIPTION
Version 0.68+ moves to a MSI file. Grains for x86/x64 for compatibility and not dealing with setting the program file variable. For loop for new versions can be extended with version numbers. The URL for downloading the file also changed.