### PR TITLE
Fix Jinja syntax error: Remove for loop and adjust variables accordingly

### DIFF
--- a/bulkrenameutility.sls
+++ b/bulkrenameutility.sls
@@ -1,16 +1,14 @@
 bulkrenameutility:
-  {% for version in ['3.0.0.1' ] %}
-  '{{ version }}':
+  '3.0.0.1':
     {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'Bulk Rename Utility {{ version }} (64-bit)'
+    full_name: 'Bulk Rename Utility 3.0 (64-bit)'
     {% elif grains['cpuarch'] == 'x86' %}
-    full_name: 'Bulk Rename Utility {{ version }} (32-bit)'
+    full_name: 'Bulk Rename Utility 3.0 (32-bit)'
     {% endif %}
-    installer: 'http://www.s3.tgrmn.com/bru/BRU_setup_{{ version }}.exe'
+    installer: 'http://www.s3.tgrmn.com/bru/BRU_setup_3.0.0.1.exe'
     install_flags: '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-'
-    uninstaller: '{{ PROGRAM_FILES }}\Bulk Rename Utility\unins000.exe'
+    uninstaller: '%PROGRAM_FILES%/Bulk Rename Utility/unins000.exe'
     uninstall_flags: '/VERYSILENT  /SUPPRESSMSGBOXES /NORESTART /SP-'
     msiexec: False
     locale: en_US
     reboot: False
-  {% endfor %


### PR DESCRIPTION
I noticed that **pkg.refresh_db** fails with the following error message:

```
ERROR: Error occurred while generating repo db. Additional info follows:

    failed:
        1
    failed_list:
        ----------
        salt-winrepo-ng\bulkrenameutility.sls:
            - Failed to compile 'salt-winrepo-ng\bulkrenameutility.sls': Jinja syntax error: expected token 'end of statement block', got '%'; line 16
              
              ---
              [...]
                  uninstaller: '{{ PROGRAM_FILES }}\Bulk Rename Utility\unins000.exe'
                  uninstall_flags: '/VERYSILENT  /SUPPRESSMSGBOXES /NORESTART /SP-'
                  msiexec: False
                  locale: en_US
                  reboot: False
                {% endfor %    <======================
              ---
    success:
        233
    total:
        234
```
Instead of adding closing curly bracket, I have removed the for loop completely since there is only 1 version.

I checked the other sls files and only 32 are using for loops.

I am wondering which approach is considered better practice when there are more than 1 versions ?