### PR TITLE
Fix bulkrenameutility recipe

### DIFF
--- a/bulkrenameutility.sls
+++ b/bulkrenameutility.sls
@@ -1,3 +1,4 @@
+{% set PROGRAM_FILES = "%ProgramFiles%" %}
 bulkrenameutility:
   {% for version in ['3.0.0.1' ] %}
   '{{ version }}':
@@ -14,3 +15,4 @@ bulkrenameutility:
     locale: en_US
     reboot: False
   {% endfor %}
+ 


### PR DESCRIPTION
Hi @UtahDave !

My earlier PR #940 was a copy paste from a real environment I patched and contained setting PROGRAM_FILES variable setting too. 

#941 solves just one part of the problem (closing the curly bracket). 

The recipe is still not working because on line 12 
`uninstaller: '{{ PROGRAM_FILES }}\Bulk Rename Utility\unins000.exe'` 
PROGRAM_FILES variable is not defined.

Anyways here is a new PR with the rebased branch :)