### PR TITLE
fixing the application names for rabbitmq and erlang

### DIFF
--- a/erlang.sls
+++ b/erlang.sls
@@ -5,7 +5,7 @@
 {% endif %}
 erlang:
   '19.3':
-    full_name: 'Erlang'
+    full_name: 'Erlang OTP (8.3)'
     {% if grains['cpuarch'] == 'AMD64' %}
     installer: 'http://erlang.org/download/otp_win64_19.3.exe'
     {% elif grains['cpuarch'] == 'x86' %}

--- a/rabbitmq.sls
+++ b/rabbitmq.sls
@@ -1,6 +1,6 @@
 rabbitmq:
   '3.6.9':
-    full_name: 'RabbitMQ'
+    full_name: 'RabbitMQ Server 3.6.9'
     installer: 'https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_9/rabbitmq-server-3.6.9.exe'
     install_flags: '/S'
     uninstaller: 'C:\Program Files\RabbitMQ Server\uninstall.exe'


### PR DESCRIPTION
Didn't name them correctly so salt wasn't able to see if they successfully installed. 