### PR TITLE
Double quote the install_flags

### DIFF
--- a/salt-minion-py2.sls
+++ b/salt-minion-py2.sls
@@ -25,7 +25,7 @@ salt-minion:
     installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py2-x86-Setup.exe'
     {% endif %}
     {% raw %}
-    #install_flags: '/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}'
+    install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
     {% endraw %}
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'

--- a/salt-minion-py3.sls
+++ b/salt-minion-py3.sls
@@ -19,7 +19,7 @@ salt-minion-py3:
     installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif %}
     {% raw %}
-    #install_flags: '/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}'
+    install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
     {% endraw %}
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'


### PR DESCRIPTION
Fixes an issue with the `installer_flags` line. It was commented out because it was failing. The fix is to double-quote the value.