### PR TITLE
Comment out the install_flags that passes master and minion

### DIFF
--- a/salt-minion-py2.sls
+++ b/salt-minion-py2.sls
@@ -25,7 +25,7 @@ salt-minion:
     installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py2-x86-Setup.exe'
     {% endif %}
     {% raw %}
-    install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
+    # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
     {% endraw %}
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'

--- a/salt-minion-py3.sls
+++ b/salt-minion-py3.sls
@@ -19,7 +19,7 @@ salt-minion-py3:
     installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif %}
     {% raw %}
-    install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
+    # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
     {% endraw %}
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'


### PR DESCRIPTION
This needs to be commented out as there is already an `install_flags` parameter set below. If they want to pass master/minion id they will have to change the .sls file accordingly. My bad.