### PR TITLE
fix typo on first line of evernote definition

### DIFF
--- a/evernote.sls
+++ b/evernote.sls
@@ -1,4 +1,4 @@
-evernote: 6.9.7.6770
+evernote:
   '6.9.7.6770':
     full_name: 'Evernote v. 6.9.7'
     installer: 'https://cdn1.evernote.com/win6/public/Evernote_6.9.7.6770.exe'


### PR DESCRIPTION
Unfortunately, I cannot test this due to the "feature" that one cannot override the default for "winrepo_remotes_ng".  We need to re-open that issue, I think.
 