### PR TITLE
Adding Microsoft Visual C++ Build Tools

### DIFF
--- a/ms-vcpp-2015-build-tools.sls
+++ b/ms-vcpp-2015-build-tools.sls
@@ -1,0 +1,9 @@
+ms-vcpp-2015-build-tools:
+  '14.0.25420.1':
+    full_name: 'Microsoft Visual C++ Build Tools'
+    installer: 'http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe'
+    install_flags: '/Q /Silent /NoRestart'
+    uninstaller: 'http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe'
+    uninstall_flags: '/Q /U /Silent /NoRestart'
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
Package for Microsoft Visual C++ Build Tools. This is required for compiling c modules for python3.5.