### PR TITLE
Revert sensu.sls to previous history

### DIFF
--- a/sensu.sls
+++ b/sensu.sls
@@ -1,33 +1,10 @@
-{% if grains['cpuarch'] == 'AMD64' %}
-    {% set cpuarch = "x64" %}
-{% else %}
-    {% set cpuarch = "x86" %}
-{% endif %}
-{% if grains['osrelease'] == '2008ServerR2' %}
-    {% set osrelease = "2008r2" %}
-{% elif grains['osrelease'] == '2008Server' %}
-    {% set osrelease = "2008" %}
-{% elif grains['osrelease'] == '2012ServerR2' %}
-    {% set osrelease = "2012r2" %}
-{% elif grains['osrelease'] == '2012Server' %}
-    {% set osrelease = "2012" %}
-{% elif grains['osrelease'] == '2016Server' %}
-    {% set osrelease = "2016" %}
-{% endif %}
 sensu:
-  {% for version in ['1.4.2',
-                     '1.0.2',
-                     '0.28.4',
-                     '0.26.5',
-                     '0.26.3',
-                     '0.25.3'] %}
-  '{{ version }}':
+  '0.26.3.1':
     full_name: 'Sensu'
-    installer: 'http://sensu.global.ssl.fastly.net/msi/{{ osrelease }}/sensu-{{ version }}-1-{{ cpuarch }}.msi'
+    installer: 'https://sensu.global.ssl.fastly.net/msi/sensu-0.26.3-1.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'http://sensu.global.ssl.fastly.net/msi/{{ osrelease }}/sensu-{{ version }}-1-{{ cpuarch }}.msi'
+    uninstaller: 'https://sensu.global.ssl.fastly.net/msi/sensu-0.26.3-1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
-  {% endfor %}


### PR DESCRIPTION
The previous update introducing osrelease windows version dependant installers, broke on all but server platforms and the author went away for github, so I am reverting back until somebody wants to update it again and properly scope it to only install on server versions of windows without breaking salt winrepo-ng yaml compilation on all other windows minions.