### PR TITLE
Update Python 2 definitions

### DIFF
--- a/python2_x64.sls
+++ b/python2_x64.sls
@@ -1,64 +1,15 @@
 python2_x64:
-  '2.7.12150':
-    full_name: 'Python 2.7.12 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.12/python-2.7.12.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.12/python-2.7.12.amd64.msi'
+  {% for minor in range(1, 16) %}
+  {% set version = '2.7.' ~ minor %}
+  {% set full_version = version ~ '150' %}
+
+  '{{ full_version }}':
+    full_name: 'Python {{ version }} (64-bit)'
+    installer: 'http://www.python.org/ftp/python/{{ version }}/python-{{ version }}.amd64.msi'
+    install_flags: '/qn ALLUSERS=1 ADDLOCAL=Extensions /norestart'
+    uninstaller: 'http://www.python.org/ftp/python/{{ version }}/python-{{ version }}.amd64.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
-  '2.7.11150':
-    full_name: 'Python 2.7.11 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.11/python-2.7.11.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.10150':
-    full_name: 'Python 2.7.10 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.9150':
-    full_name: 'Python 2.7.9 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.8150':
-    full_name: 'Python 2.7.8 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.7150':
-    full_name: 'Python 2.7.7 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.6150':
-    full_name: 'Python 2.7.6 (64-bit)'
-    installer: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi'
-    install_flags: '/qn ALLUSERS=1 /norestart'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.amd64.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
+  {% endfor %}

--- a/python2_x86.sls
+++ b/python2_x86.sls
@@ -1,64 +1,15 @@
 python2_x86:
-  '2.7.12150':
-    full_name: 'Python 2.7.12'
-    installer: 'http://www.python.org/ftp/python/2.7.12/python-2.7.12.msi'
+  {% for minor in range(1, 16) %}
+  {% set version = '2.7.' ~ minor %}
+  {% set full_version = version ~ '150' %}
+
+  '{{ full_version }}':
+    full_name: 'Python {{ version }}'
+    installer: 'http://www.python.org/ftp/python/{{ version }}/python-{{ version }}.msi'
     install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.12/python-2.7.12.msi'
+    uninstaller: 'http://www.python.org/ftp/python/{{ version }}/python-{{ version }}.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
-  '2.7.11150':
-    full_name: 'Python 2.7.11'
-    installer: 'http://www.python.org/ftp/python/2.7.11/python-2.7.11.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.11/python-2.7.11.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.10150':
-    full_name: 'Python 2.7.10'
-    installer: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.10/python-2.7.10.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.9150':
-    full_name: 'Python 2.7.9'
-    installer: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.9/python-2.7.9.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.8150':
-    full_name: 'Python 2.7.8'
-    installer: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.7150':
-    full_name: 'Python 2.7.7'
-    installer: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.7/python-2.7.7.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
-  '2.7.6150':
-    full_name: 'Python 2.7.6'
-    installer: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.msi'
-    install_flags: '/qn /norestart ALLUSERS=1'
-    uninstaller: 'http://www.python.org/ftp/python/2.7.6/python-2.7.6.msi'
-    uninstall_flags: '/qn /norestart'
-    msiexec: True
-    locale: en_US
-    reboot: False
+  {% endfor %}


### PR DESCRIPTION
Update the Python 2 definitions to include the lastest versions.

I switched the code to use a Jinja loop over the version numbers, so it is a lot cleaner.  I did not include the Python 3 definitions; while those are also well behind, the format is more complicated, so needs a bit more work. 