### PR TITLE
Add RabbitMQ version 3.7.7

### DIFF
--- a/rabbitmq.sls
+++ b/rabbitmq.sls
@@ -1,10 +1,13 @@
+{% set versions = [('3.6.9', 'rabbitmq_v3_6_9'), ('3.7.7', 'v3.7.7')] %}
 rabbitmq:
-  '3.6.9':
-    full_name: 'RabbitMQ Server 3.6.9'
-    installer: 'https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v3_6_9/rabbitmq-server-3.6.9.exe'
+  {% for version, tag in versions %}
+  '{{ version }}':
+    full_name: 'RabbitMQ Server {{ version }}'
+    installer: 'https://github.com/rabbitmq/rabbitmq-server/releases/download/{{ tag }}/rabbitmq-server-{{ version }}.exe'
     install_flags: '/S'
     uninstaller: 'C:\Program Files\RabbitMQ Server\uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False
     locale: en_US
     reboot: False
+  {% endfor %}


### PR DESCRIPTION
This adds RabbitMQ 3.7.7 which is compatible with the Erlang 21.0.1.