### PR TITLE
Correcting Python not being recognised as installed

### DIFF
--- a/python3_x64.sls
+++ b/python3_x64.sls
@@ -1,6 +1,6 @@
 python3_x64:
   '3.7.150.0':
-    full_name: 'Python Core Interpreter 3.7.0 (64-bit)'
+    full_name: 'Python 3.7.0 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.7.0/python-3.7.0-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.7.0/python-3.7.0-amd64.exe'
@@ -9,7 +9,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.5.2150.0':
-    full_name: 'Python Core Interpreter 3.5.2 (64-bit)'
+    full_name: 'Python 3.5.2 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe'
@@ -18,7 +18,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.5.1150.0':
-    full_name: 'Python Core Interpreter 3.5.1 (64-bit)'
+    full_name: 'Python 3.5.1 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.5.1/python-3.5.1-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.5.1/python-3.5.1-amd64.exe'
@@ -27,7 +27,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.3150':
-    full_name: 'Python Core Interpreter 3.4.3 (64-bit)'
+    full_name: 'Python 3.4.3 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi'
@@ -36,7 +36,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.2150':
-    full_name: 'Python Core Interpreter 3.4.2 (64-bit)'
+    full_name: 'Python 3.4.2 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi'
@@ -45,7 +45,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.1150':
-    full_name: 'Python Core Interpreter 3.4.1 (64-bit)'
+    full_name: 'Python 3.4.1 Core Interpreter (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.amd64.msi'
@@ -54,7 +54,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.3.3150':
-    full_name: 'Python Core Interpreter 3.3.3 (64-bit)'
+    full_name: 'Python 3.3.3 Core Interpreter (64-bit)'
     installer: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.amd64.msi'

--- a/python3_x64.sls
+++ b/python3_x64.sls
@@ -1,6 +1,6 @@
 python3_x64:
   '3.7.150.0':
-    full_name: 'Python 3.7.0 (64-bit)'
+    full_name: 'Python Core Interpreter 3.7.0 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.7.0/python-3.7.0-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.7.0/python-3.7.0-amd64.exe'
@@ -9,7 +9,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.5.2150.0':
-    full_name: 'Python 3.5.2 (64-bit)'
+    full_name: 'Python Core Interpreter 3.5.2 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.5.2/python-3.5.2-amd64.exe'
@@ -18,7 +18,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.5.1150.0':
-    full_name: 'Python 3.5.1 (64-bit)'
+    full_name: 'Python Core Interpreter 3.5.1 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.5.1/python-3.5.1-amd64.exe'
     install_flags: '/quiet InstallAllUsers=1'
     uninstaller: 'https://www.python.org/ftp/python/3.5.1/python-3.5.1-amd64.exe'
@@ -27,7 +27,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.3150':
-    full_name: 'Python 3.4.3 (64-bit)'
+    full_name: 'Python Core Interpreter 3.4.3 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.3/python-3.4.3.amd64.msi'
@@ -36,7 +36,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.2150':
-    full_name: 'Python 3.4.2 (64-bit)'
+    full_name: 'Python Core Interpreter 3.4.2 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.2/python-3.4.2.amd64.msi'
@@ -45,7 +45,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.4.1150':
-    full_name: 'Python 3.4.1 (64-bit)'
+    full_name: 'Python Core Interpreter 3.4.1 (64-bit)'
     installer: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'https://www.python.org/ftp/python/3.4.1/python-3.4.1.amd64.msi'
@@ -54,7 +54,7 @@ python3_x64:
     locale: en_US
     reboot: False
   '3.3.3150':
-    full_name: 'Python 3.3.3 (64-bit)'
+    full_name: 'Python Core Interpreter 3.3.3 (64-bit)'
     installer: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.amd64.msi'
     install_flags: '/qn ALLUSERS=1 /norestart'
     uninstaller: 'http://www.python.org/ftp/python/3.3.3/python-3.3.3.amd64.msi'


### PR DESCRIPTION
Apologies if this is not how this is done. First time on github, and using git.

I noticed that Python is not being recognised as installed after a state.apply is run so it is reinstalled every time. Looking at the output of a pkg.list_pkgs there was not a listing that matched what was in the python3_x64.sls. There were listings relating to the Python install eg/ Python 3.5.2 Executables (64-bit) and Python 3.5.2 Core Interpreter (64-bit), adding “Core Interpreter” seemed the most logical to confirm that Python was installed. 

Again, please let me know if this is all wrong.