### PR TITLE
adding Microsoft Visual C++ Redistributable for Visual Studio 2019 (x64)

### DIFF
--- a/ms-vcpp-2017-redist_x64.sls
+++ b/ms-vcpp-2017-redist_x64.sls
@@ -1,0 +1,10 @@
+ms-vcpp-2017-redist_x64:
+  '14.20.27508':
+    full_name: 'Microsoft Visual C++ 2017 Redistributable (x64) - 14.20.27508'
+    installer: 'https://download.visualstudio.microsoft.com/download/pr/602ece0b-dae9-4f47-84c5-240dc997483e/5a0b5cec555e06240d79eb4ac6bc8973/vc_redist.x64.exe'
+    install_flags: '/quiet /norestart'
+    uninstaller: 'https://download.visualstudio.microsoft.com/download/pr/602ece0b-dae9-4f47-84c5-240dc997483e/5a0b5cec555e06240d79eb4ac6bc8973/vc_redist.x64.exe'
+    uninstall_flags: '/uninstall /quiet /norestart'
+    msiexec: False
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
used `ms-vcpp-2017-redist_x86.sls` as a template and changed the URL to the one obtained from un-shortening the `aka.ms` URL found [here](https://visualstudio.microsoft.com/downloads/)