### PR TITLE
Zabbix Agent installer

### DIFF
--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -5,6 +5,8 @@ zabbix-agent:
     installer: 'https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi'
     {% endif %}
     install_flags: '/quiet SERVER=localhost'
+    uninstaller: 'msiexec.exe'
+    uninstall_flags: '/x https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi /quiet'
     locale: en_US
     reboot: False
   '4.0.9.2400':
@@ -13,6 +15,8 @@ zabbix-agent:
     installer: 'https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi'
     {% endif %}
     install_flags: '/quiet SERVER=localhost'
+    uninstaller: 'msiexec.exe'
+    uninstall_flags: '/x https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi /quiet'
     locale: en_US
     reboot: False
   '3.0.28.2400':
@@ -21,5 +25,7 @@ zabbix-agent:
     installer: 'https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi'
     {% endif %}
     install_flags: '/quiet SERVER=localhost'
+    uninstaller: 'msiexec.exe'
+    uninstall_flags: '/x https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi /quiet'
     locale: en_US
     reboot: False

--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -6,16 +6,18 @@ zabbix-agent:
 {% for major, subversions in versions.items() %}
 {% for minor in subversions %}
   '{{major}}.{{minor}}.2400':
-    full_name: 'Zabbix Agent (64-bit)'
     {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
     installer: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-amd64-openssl.msi'
-    uninstall_flags: '/x {{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-amd64-openssl.msi /quiet'
+    uninstaller: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-amd64-openssl.msi'
     {% else %}
+    full_name: 'Zabbix Agent'
     installer: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi'
-    uninstall_flags: '/x {{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi /quiet'
+    uninstaller:  '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi'
     {% endif %}
-    install_flags: '/quiet SERVER=localhost'
-    uninstaller: 'msiexec.exe'
+    install_flags: '/qn SERVER=localhost'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
     locale: en_US
     reboot: False
 {% endfor %}

--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -1,5 +1,5 @@
 zabbix-agent:
-  4.2.3.2400:
+  '4.2.3.2400':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Zabbix Agent (64-bit)'
     installer: 'https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi'
@@ -7,7 +7,7 @@ zabbix-agent:
     install_flags: '/quiet SERVER=localhost'
     locale: en_US
     reboot: False
-  4.0.9.2400:
+  '4.0.9.2400':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Zabbix Agent (64-bit)'
     installer: 'https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi'
@@ -15,7 +15,7 @@ zabbix-agent:
     install_flags: '/quiet SERVER=localhost'
     locale: en_US
     reboot: False
-  3.0.28.2400:
+  '3.0.28.2400':
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Zabbix Agent (64-bit)'
     installer: 'https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi'

--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -15,7 +15,7 @@ zabbix-agent:
     installer: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi'
     uninstaller:  '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi'
     {% endif %}
-    install_flags: '/qn SERVER=localhost'
+    install_flags: '/qn /norestart SERVER=localhost'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US

--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -1,4 +1,4 @@
-zabbix_agent:
+zabbix-agent:
   4.2.3.2400:
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Zabbix Agent (64-bit)'

--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -1,31 +1,22 @@
+# both 32-bit (x86) AND a 64-bit (AMD64) installer available
+{% set versions = {'4.2':['3'], '4.0':[9], '3.0':[28]} %}
+{% set source_path = 'https://www.zabbix.com/downloads/' %}
+
 zabbix-agent:
-  '4.2.3.2400':
-    {% if grains['cpuarch'] == 'AMD64' %}
+{% for major, subversions in versions.items() %}
+{% for minor in subversions %}
+  '{{major}}.{{minor}}.2400':
     full_name: 'Zabbix Agent (64-bit)'
-    installer: 'https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi'
+    {% if grains['cpuarch'] == 'AMD64' %}
+    installer: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-amd64-openssl.msi'
+    uninstall_flags: '/x {{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-amd64-openssl.msi /quiet'
+    {% else %}
+    installer: '{{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi'
+    uninstall_flags: '/x {{source_path}}{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-win-i386-openssl.msi /quiet'
     {% endif %}
     install_flags: '/quiet SERVER=localhost'
     uninstaller: 'msiexec.exe'
-    uninstall_flags: '/x https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi /quiet'
     locale: en_US
     reboot: False
-  '4.0.9.2400':
-    {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'Zabbix Agent (64-bit)'
-    installer: 'https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi'
-    {% endif %}
-    install_flags: '/quiet SERVER=localhost'
-    uninstaller: 'msiexec.exe'
-    uninstall_flags: '/x https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi /quiet'
-    locale: en_US
-    reboot: False
-  '3.0.28.2400':
-    {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'Zabbix Agent (64-bit)'
-    installer: 'https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi'
-    {% endif %}
-    install_flags: '/quiet SERVER=localhost'
-    uninstaller: 'msiexec.exe'
-    uninstall_flags: '/x https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi /quiet'
-    locale: en_US
-    reboot: False
+{% endfor %}
+{% endfor %}

--- a/zabbix_agent.sls
+++ b/zabbix_agent.sls
@@ -1,0 +1,25 @@
+zabbix_agent:
+  4.2.3.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False
+  4.0.9.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False
+  3.0.28.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
Currently this only works for x64 based windows as I don't have a x86 based windows server and the agent won't allow you to do an x86 based install on the x64 based server.

Also I have been unable to get the agent to uninstall via cli in quiet mode properly, windows tells me the client is not installed or other things and so the uninstall fails unless you do a full removal from the windows programs and features center.