### PR TITLE
Adding TightVNC versions 2.8.23 and 2.8.27

### DIFF
--- a/tightvnc.sls
+++ b/tightvnc.sls
@@ -1,5 +1,5 @@
 tightvnc:
-  {% for version in ['2.8.11', '2.8.8', '2.8.5', '2.8.2', '2.7.10'] %}
+  {% for version in ['2.8.27', '2.8.23', '2.8.11', '2.8.8', '2.8.5', '2.8.2', '2.7.10'] %}
   {% set full_version = version ~ '.0' %}
   '{{ full_version }}':
     full_name: 'TightVNC'


### PR DESCRIPTION
New versions of TightVNC are available (see: https://www.tightvnc.com/whatsnew.php). This PR adds them to the SLS.