### PR TITLE
Filebeat fix updateable

### DIFF
--- a/filebeat/install.ps1
+++ b/filebeat/install.ps1
@@ -27,6 +27,9 @@ $client.DownloadFile($url, $zip_file)
 $ProgressPreference = "SilentlyContinue"
 Get-ChildItem $zip_file | Expand-Archive -DestinationPath $env:ProgramFiles -Force
 
+# delete old filebeat folder
+Remove-Item -Force -Recurse -Path "$env:ProgramFiles\Filebeat"
+
 # Rename the directory
 Rename-Item -Path "$env:ProgramFiles\filebeat-$version-windows-x86_64" -NewName "Filebeat"
 

--- a/filebeat/install.ps1
+++ b/filebeat/install.ps1
@@ -28,7 +28,7 @@ $ProgressPreference = "SilentlyContinue"
 Get-ChildItem $zip_file | Expand-Archive -DestinationPath $env:ProgramFiles -Force
 
 # delete old filebeat folder
-Remove-Item -Force -Recurse -Path "$env:ProgramFiles\Filebeat"
+Remove-Item -Force -Recurse -Path "$env:ProgramFiles\Filebeat" -ErrorAction Ignore
 
 # Rename the directory
 Rename-Item -Path "$env:ProgramFiles\filebeat-$version-windows-x86_64" -NewName "Filebeat"


### PR DESCRIPTION
if filebeat is allreay installed the directory can not be renamed, this causes the state.apply to fail.

solution remove the old directory. When a new version should be applied.