### PR TITLE
Updated to the latest version (8u251 b08)

### DIFF
--- a/jre8.sls
+++ b/jre8.sls
@@ -5,7 +5,7 @@
 # you more versions and also different builds. IF you do use these, make sure you adapt your sls file accordingly.  
 # http://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html
 
-{% set versions = {'8.0':['2010.9','2110.9','2210.9','2310.9','2410.7']} %}
+{% set versions = {'8.0':['2010.9','2110.9','2210.9','2310.9','2410.7','2510.8']} %}
 
 jre8:
 {% for major, subversions in versions.items() %}


### PR DESCRIPTION
Information from the [release notes](https://www.oracle.com/technetwork/java/javase/8u251-relnotes-5972664.html).

Side note: Do we need to... 
a) have the Security Baselines number in there? 
b) go back and update the rest of them what the GA build at the time of the release notes?

For example:
- 2310.9 -> 2311.1 -> https://www.oracle.com/technetwork/java/javase/8u231-relnotes-5592812.html

- 2210.9 -> 2211.1 -> https://www.oracle.com/technetwork/java/javase/8u221-relnotes-5480116.html