### PR TITLE
Added version and path array for 3.2

### DIFF
--- a/sumatrapdf.sls
+++ b/sumatrapdf.sls
@@ -1,15 +1,18 @@
-{% if grains['cpuarch'] == 'AMD64' %}
-    {% set INSTALLER = "SumatraPDF-3.1.2-64-install.exe" %}
-{% else %}
-    {% set INSTALLER = "SumatraPDF-3.1.2-install.exe" %}
-{% endif %}
+{% set versions = [('3.2',  'dl2'),
+                   ('3.1.2', 'dl')] %}
 sumatrapdf:
-  '3.1.2':
+  {% for version, path in versions %}
+  '{{ version }}':
     full_name: 'SumatraPDF'
-    installer: 'https://www.sumatrapdfreader.org/dl/{{ INSTALLER }}'
+    {% if grains['cpuarch'] == 'AMD64' %}
+    installer: 'https://www.sumatrapdfreader.org/{{ path }}/SumatraPDF-{{ version }}-64-install.exe'
+    {% else  %}
+    installer: 'https://www.sumatrapdfreader.org/{{ path }}/SumatraPDF-{{ version }}-install.exe'
+    {% endif %}
     install_flags: '/s /opt'
     uninstaller: '%ProgramFiles%\SumatraPDF\uninstall.exe'
     uninstall_flags: '/s'
     msiexec: False
     locale: en_US
     reboot: False
+  {% endfor %}


### PR DESCRIPTION
Wish new versions didn't use an arbitrarily different path :(

Tested with `pkg.install sumatrapdf version=3.2`