### PR TITLE
Fixed 32-bit zabbix agent not being recognized as installed

### DIFF
--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -11,7 +11,7 @@ zabbix-agent:
     installer: '{{source_path}}{{major}}/{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-windows-amd64-openssl.msi'
     uninstaller: '{{source_path}}{{major}}/{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-windows-amd64-openssl.msi'
     {% else %}
-    full_name: 'Zabbix Agent'
+    full_name: 'Zabbix Agent (32-bit)'
     installer: '{{source_path}}{{major}}/{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-windows-i386-openssl.msi'
     uninstaller:  '{{source_path}}{{major}}/{{major}}.{{minor}}/zabbix_agent-{{major}}.{{minor}}-windows-i386-openssl.msi'
     {% endif %}


### PR DESCRIPTION
Fixes: https://github.com/saltstack/salt/issues/60032

The zabbix 32-bit agent needed the full_name attribute updated to reflect the listing in the programs and features list. Before applying this change, the 32-bit version of Zabbix would install properly, but salt would fail to recognize the program as installed.

After applying this change, salt now recognizes the program as installed, which allows any automation that must be triggered on installation (or having the program already installed) to run as expected.