### PR TITLE
Updated tortoise-hg to current 2021 version

### DIFF
--- a/tortoise-hg.sls
+++ b/tortoise-hg.sls
@@ -1,5 +1,3 @@
-# Source: http://tortoisehg.bitbucket.org/
-
 {% if grains['cpuarch'] == 'AMD64' %}
 {% set msi_arch = 'x64' %}
 {% else %}
@@ -7,6 +5,10 @@
 {% endif %}
 
 tortoise-hg:
+  '5.7.1':
+    full_name: 'TortoiseHg 5.7.1 ({{ msi_arch }})'
+    installer: 'https://www.mercurial-scm.org/release/tortoisehg/windows/tortoisehg-5.7.1-{{ msi_arch }}.msi'
+    uninstaller: 'https://www.mercurial-scm.org/release/tortoisehg/windows/tortoisehg-5.7.1-{{ msi_arch }}.msi'
   '3.6.2':
     full_name: 'TortoiseHg 3.6.2 ({{ msi_arch }})'
     installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-{{ msi_arch }}.msi'
@@ -25,5 +27,7 @@ tortoise-hg:
     msiexec: True
     locale: en_US
     reboot: False
-# Need to download from source site above, so it will append proper aws key credentials
-# place downloaded msi in master's win_repo-ng
+# Installers for versions 3.x.y had to be downloaded
+# from http://tortoisehg.bitbucket.org (not existing anymore)
+# so it appended proper aws key credentials
+# and placed in master's win_repo-ng

--- a/tortoise-hg.sls
+++ b/tortoise-hg.sls
@@ -11,18 +11,14 @@ tortoise-hg:
     uninstaller: 'https://www.mercurial-scm.org/release/tortoisehg/windows/tortoisehg-5.7.1-{{ msi_arch }}.msi'
   '3.6.2':
     full_name: 'TortoiseHg 3.6.2 ({{ msi_arch }})'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-{{ msi_arch }}.msi'
     uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-{{ msi_arch }}.msi'
-    install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '3.3.0':
     full_name: 'TortoiseHg 3.3.0 ({{ msi_arch }})'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-{{ msi_arch }}.msi'
     uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-{{ msi_arch }}.msi'
-    install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US

--- a/tortoise-hg.sls
+++ b/tortoise-hg.sls
@@ -1,30 +1,25 @@
 # Source: http://tortoisehg.bitbucket.org/
+
+{% if grains['cpuarch'] == 'AMD64' %}
+{% set msi_arch = 'x64' %}
+{% else %}
+{% set msi_arch = 'x86' %}
+{% endif %}
+
 tortoise-hg:
   '3.6.2':
-    {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'TortoiseHg 3.6.2 (x64)'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x64.msi'
-    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x64.msi'
-    {% else %}
-    full_name: 'TortoiseHg 3.6.2 (x86)'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x86.msi'
-    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-x86.msi'
-    {% endif %}
+    full_name: 'TortoiseHg 3.6.2 ({{ msi_arch }})'
+    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-{{ msi_arch }}.msi'
+    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.6.2-{{ msi_arch }}.msi'
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '3.3.0':
-    {% if grains['cpuarch'] == 'AMD64' %}
-    full_name: 'TortoiseHg 3.3.0 (x64)'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-x64.msi'
-    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-x64.msi'
-    {% else %}
-    full_name: 'TortoiseHg 3.3.0 (x86)'
-    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-x86.msi'
-    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-x86.msi'
-    {% endif %}
+    full_name: 'TortoiseHg 3.3.0 ({{ msi_arch }})'
+    installer: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-{{ msi_arch }}.msi'
+    uninstaller: 'salt://win/repo-ng/tortoise-hg/tortoisehg-3.3.0-{{ msi_arch }}.msi'
     install_flags: '/qn /norestart'
     uninstall_flags: '/qn /norestart'
     msiexec: True


### PR DESCRIPTION
The previously listed versions were out of support for years.

Context: I am a Mercurial core contributor, currently working to provide Windows CI resources for the Mercurial and TortoiseHg projects, and been using Salt on Linux for years (with some minor contribs). 

Being able to manage these machines with Salt will be a drastic simplification to me so I'd like to thank you for making salt_winrepo_ng.

The new definition works for me on an amd64 (x64) VM with Windows Server 2019.

I didn't have the occasion to try it on x86, that's why I kept a general `else` Jinja clause instead of comparing to the actual architecture.

