### PR TITLE
Added latest LTS releases for Blender (2.93.0, 2.83.15, and 2.83.14).

### DIFF
--- a/blender.sls
+++ b/blender.sls
@@ -15,3 +15,17 @@ blender:
     msiexec: True
     locale: en_US
     reboot: False
+
+# Note: Since April/May 2021, installer name has changed slightly (windows64 -> windows-x64).
+# Note2: Newer versions of Blender do not provide 32-bit installers anymore.
+{% for version, patch in [('2.93', '0'), ('2.83', '15'), ('2.83', '14')] %}
+  '{{ version }}':
+    full_name: 'Blender'
+    installer: 'https://ftp.nluug.nl/pub/graphics/blender/release/Blender{{version}}/blender-{{version}}.{{patch}}-windows-x64.msi'
+    uninstaller: 'https://ftp.nluug.nl/pub/graphics/blender/release/Blender{{version}}/blender-{{version}}.{{patch}}-windows-x64.msi'
+    install_flags: '/qn /norestart'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
+{% endfor %}

--- a/blender.sls
+++ b/blender.sls
@@ -19,8 +19,8 @@ blender:
 # Note: Since April/May 2021, installer name has changed slightly (windows64 -> windows-x64).
 # Note2: Newer versions of Blender do not provide 32-bit installers anymore.
 {% for version, patch in [('2.93', '0'), ('2.83', '15'), ('2.83', '14')] %}
-  '{{ version }}':
-    full_name: 'Blender'
+  '{{ version }}.{{ patch }}':
+    full_name: 'blender'
     installer: 'https://ftp.nluug.nl/pub/graphics/blender/release/Blender{{version}}/blender-{{version}}.{{patch}}-windows-x64.msi'
     uninstaller: 'https://ftp.nluug.nl/pub/graphics/blender/release/Blender{{version}}/blender-{{version}}.{{patch}}-windows-x64.msi'
     install_flags: '/qn /norestart'


### PR DESCRIPTION
This updates the blender.sls definition to include the latest LTS releases (2.93.0 and 2.83.15).

This only defines 64-bit installers as blender doesn't support 32-bit for Windows since version 2.80 (See: https://developer.blender.org/T67184)