### PR TITLE
tests: use Salt to render the sls files

### DIFF
--- a/.cicd/minion
+++ b/.cicd/minion
@@ -1,0 +1,7 @@
+root_dir: /tmp/salt
+disable_fqdn_grains: true
+file_client: local
+# Pretend that we're running on Windows
+providers:
+  pkg: win_pkg
+  winrepo: winrepo

--- a/.cicd/requirements.txt
+++ b/.cicd/requirements.txt
@@ -1,6 +1,5 @@
 gitpython
-jinja2
-pyaml
 pycurl
 python-magic
+salt
 tabulate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,7 @@ repos:
         types: [salt]
         additional_dependencies:
           - gitpython
-          - jinja2
-          - pyaml
           - pycurl
           - python-magic
+          - salt
           - tabulate


### PR DESCRIPTION
Use Salt itself to render and process the package `.sls` files.

Advantages of this is we can properly process and use Salt internal functions like `salt.pkg.compare_versions` or Jinja filters like `yaml_encode`.