### PR TITLE
Update winrar.sls

### DIFF
--- a/winrar.sls
+++ b/winrar.sls
@@ -1,5 +1,5 @@
 #if possible use 5.70 or newer due to vulnerabilities (CVE-2018-20250, CVE-2018-20251, CVE-2018-20252, CVE-2018-20253)
-{% set versions = {'5':['91', '70', '61']} %}
+{% set versions = {'5':['91', '70', '61'], '6':['02', '01', '00']} %}
 
 winrar:
 {% for major, subversions in versions.items() %}


### PR DESCRIPTION
Added v6 versions
Because the links to older betas are removed by RarLab, betas are not included.