### PR TITLE
salt-minion-py3: fix uninstall of v3004+

### DIFF
--- a/salt-minion-py3.sls
+++ b/salt-minion-py3.sls
@@ -21,9 +21,9 @@ salt-minion-py3:
   '{{ version }}':
     full_name: 'Salt Minion {{ version }} (Python 3)'
     {% if grains['cpuarch'] == 'AMD64' %}
-    installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py3-AMD64-Setup.exe'
+    installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-AMD64-Setup.exe'
     {% else %}
-    installer: 'https://repo.saltstack.com/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
+    installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif %}
     {% raw %}
     # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
@@ -37,7 +37,7 @@ salt-minion-py3:
   {% endfor %}
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Versions of Salt that contain CVE's have been moved to an archive at:
-# archive.repo.saltstack.com/windows. The ability to install those versions
+# archive.repo.saltproject.io/windows. The ability to install those versions
 # using winrepo has been removed.
 # An uninstall only definition will remain here so the packages will show up
 # correctly in `pkg.list_pkgs` and to allow for removal using `pkg.remove`

--- a/salt-minion-py3.sls
+++ b/salt-minion-py3.sls
@@ -1,12 +1,3 @@
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# This software definition will only work in versions of Salt newer than
-# 2015.8.2. In version 2015.8.2 we added the `use_scheduler` option which
-# allowed us to launch the installer using the Windows task manager.
-# This option is not available in earlier versions of Salt. So, while this
-# software definition will allow you to install versions of Salt older than
-# 2015.8.2 you will not be able to use pkg.install to upgrade Salt again. You
-# will have to upgrade Salt through another means.
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 salt-minion-py3:
   {%
       for version in [
@@ -25,9 +16,6 @@ salt-minion-py3:
     {% else %}
     installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif %}
-    {% raw %}
-    # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
-    {% endraw %}
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'
     uninstall_flags: '/S'

--- a/salt-minion-py3.sls
+++ b/salt-minion-py3.sls
@@ -1,3 +1,5 @@
+{% set install_dir = salt["reg.read_value"]("HKLM", "SOFTWARE\\Salt Project\\Salt", "install_dir").vdata %}
+{% set install_dir = install_dir or "C:\\salt" %}
 salt-minion-py3:
   {%
       for version in [
@@ -17,7 +19,7 @@ salt-minion-py3:
     installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif %}
     install_flags: '/S'
-    uninstaller: 'C:\salt\uninst.exe'
+    uninstaller: '{{ install_dir }}\uninst.exe'
     uninstall_flags: '/S'
     msiexec: False
     use_scheduler: True
@@ -86,7 +88,7 @@ salt-minion-py3:
   '{{ version }}':
     skip_urltest: True
     full_name: 'Salt Minion {{ version }} (Python 3)'
-    uninstaller: 'C:\salt\uninst.exe'
+    uninstaller: '{{ install_dir }}\uninst.exe'
     uninstall_flags: '/S'
     use_scheduler: True
   {% endfor %}


### PR DESCRIPTION
- salt-minion-py3: switch to `repo.saltproject.io`
- salt-minion-py3: remove unnecessary comments
- salt-minion-py3: use registry install_dir for uninstaller where necessary
