### PR TITLE
Added latest Blender LTS patch releases (2.93 & 2.83)

### DIFF
--- a/blender.sls
+++ b/blender.sls
@@ -18,7 +18,19 @@ blender:
 
 # Note: Since April/May 2021, installer name has changed slightly (windows64 -> windows-x64).
 # Note2: Newer versions of Blender do not provide 32-bit installers anymore.
-{% for version, patch in [('2.93', '0'), ('2.83', '15'), ('2.83', '14')] %}
+{% for version, patch in [('2.93', '7'),
+                          ('2.93', '6'),
+                          ('2.93', '5'),
+                          ('2.93', '4'),
+                          ('2.93', '3'),
+                          ('2.93', '2'),
+                          ('2.93', '1'),
+                          ('2.93', '0'),
+                          ('2.83', '18'),
+                          ('2.83', '17'),
+                          ('2.83', '16'),
+                          ('2.83', '15'),
+                          ('2.83', '14')] %}
   '{{ version }}.{{ patch }}':
     full_name: 'blender'
     installer: 'https://ftp.nluug.nl/pub/graphics/blender/release/Blender{{version}}/blender-{{version}}.{{patch}}-windows-x64.msi'


### PR DESCRIPTION
Updated with all patch versions of LTS releases between now and the existing definitions.

(Does not include 3.0; not an LTS release).