### PR TITLE
ci: fix for missing `GitPython`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup `pip` dependencies
         if: steps.changed-files.outputs.sls == 'true'
         run: |
-          salt-pip install python-magic-bin tabulate
+          salt-pip install python-magic-bin tabulate gitpython
           if ($LASTEXITCODE) {
               Write-Host ("::error title=salt-pip::salt-pip returned exit code: $LASTEXITCODE")
               exit 1


### PR DESCRIPTION
At a cursory glance it appears that `GitPython` is missing from the new Salt release `v3007.0`.

This is a quick fix pending further investigation.