### PR TITLE
chore(deps): update dafyddj/get-salt-versions action to v3

### DIFF
--- a/.github/workflows/full_run_win.yml
+++ b/.github/workflows/full_run_win.yml
@@ -17,7 +17,7 @@ jobs:
       salt-latest: ${{ steps.get-salt-versions.outputs.salt-latest }}
     steps:
       - id: get-salt-versions
-        uses: dafyddj/get-salt-versions@facbecc73d55759ff6940c48e22dfa52e6e74f63 # v2.13.0
+        uses: dafyddj/get-salt-versions@1fcbea0eee4404137e534d66f3c22846f7c2a7ec # v3.0.0
   test:
     name: Run URL tests
     needs: gsv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       salt-latest: ${{ steps.get-salt-versions.outputs.salt-latest }}
     steps:
       - id: get-salt-versions
-        uses: dafyddj/get-salt-versions@facbecc73d55759ff6940c48e22dfa52e6e74f63 # v2.13.0
+        uses: dafyddj/get-salt-versions@1fcbea0eee4404137e534d66f3c22846f7c2a7ec # v3.0.0
   test:
     name: Run URL tests
     needs: gsv

--- a/.github/workflows/refresh_db.yml
+++ b/.github/workflows/refresh_db.yml
@@ -11,10 +11,11 @@ jobs:
     name: Get Salt versions
     runs-on: ubuntu-latest
     outputs:
+      salt-versions-els: ${{ steps.get-salt-versions.outputs.salt-versions-els }}
       salt-versions: ${{ steps.get-salt-versions.outputs.salt-versions }}
     steps:
       - id: get-salt-versions
-        uses: dafyddj/get-salt-versions@facbecc73d55759ff6940c48e22dfa52e6e74f63 # v2.13.0
+        uses: dafyddj/get-salt-versions@1fcbea0eee4404137e534d66f3c22846f7c2a7ec # v3.0.0
   test:
     name: Test `pkg.refresh_db`
     needs: gsv
@@ -22,7 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        salt-version: ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
+        salt-version:
+          - ${{ fromJSON(needs.gsv.outputs.salt-versions-els) }}
+          - ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
This expands the testing (pkg.refresh_db) to include Salt versions on extended life support,
where previously the version choice was more ad-hoc.
