### PR TITLE
Fix repo path

### DIFF
--- a/auditbeat/init.sls
+++ b/auditbeat/init.sls
@@ -12,8 +12,8 @@ auditbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Auditbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/auditbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/auditbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/auditbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/auditbeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/bitwarden-cli/init.sls
+++ b/bitwarden-cli/init.sls
@@ -11,8 +11,8 @@ bitwarden-cli:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Bitwarden CLI {{ version }}'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/bitwarden-cli/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/bitwarden-cli/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/bitwarden-cli/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/bitwarden-cli/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/chocolatey/init.sls
+++ b/chocolatey/init.sls
@@ -1,8 +1,8 @@
 chocolatey:
   latest:
     full_name: 'Chocolatey'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/chocolatey/install.cmd'
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/chocolatey/uninstall.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/chocolatey/install.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/chocolatey/uninstall.cmd'
     cache_dir: True
 
 # this software also has it's own salt execution module, which you might prefer to use, see

--- a/cwrsync/init.sls
+++ b/cwrsync/init.sls
@@ -20,8 +20,8 @@ cwrsync:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'cwRsync'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/cwrsync/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/cwrsync/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/cwrsync/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/cwrsync/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/erlang/init.sls
+++ b/erlang/init.sls
@@ -21,7 +21,7 @@ erlang:
   {% set major_version = otp_version.split(".")[0] | int %}
   '{{ otp_version }}':
     full_name: 'Erlang OTP {{ display_version }} ({{ erlang_version }})'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/erlang/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/erlang/install.cmd'
     install_flags: '"http://erlang.org/download/otp_win{{ BITS }}_{{ otp_version }}.exe" "otp_win{{ BITS }}_{{ otp_version }}.exe" "{{ otp_version }}" "Erlang OTP {{ otp_version.split('.')[0] }} ({{ erlang_version }})" "/S"'
     {% if major_version >= 23 %}
     uninstaller: '%ProgramFiles%\erl-{{ otp_version }}\Uninstall.exe'

--- a/filebeat/init.sls
+++ b/filebeat/init.sls
@@ -12,8 +12,8 @@ filebeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Filebeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/filebeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/filebeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/filebeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/filebeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/functionbeat/init.sls
+++ b/functionbeat/init.sls
@@ -12,8 +12,8 @@ functionbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Functionbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/functionbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/functionbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/functionbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/functionbeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/gpg4win/init.sls
+++ b/gpg4win/init.sls
@@ -43,10 +43,10 @@ gpg4win:
   {{ VERSION }}:
     full_name: 'Gpg4win ({{ VERSION }})'
     installer: 'http://files.gpg4win.org/gpg4win-{{ VERSION }}.exe'
-    install_flags: '/S /C="C:\ProgramData\Salt Project\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng\gpg4win\silent.ini"'
+    install_flags: '/S /C="C:\ProgramData\Salt Project\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng\_\gpg4win\silent.ini"'
     uninstaller: '{{ PROGRAM_FILES }}\gpg4win\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
-    cache_file: salt://win/repo-ng/salt-winrepo-ng/gpg4win/silent.ini
+    cache_file: salt://win/repo-ng/salt-winrepo-ng/_/gpg4win/silent.ini
     msiexec: False
     reboot: False
   {% endfor %}

--- a/heartbeat/init.sls
+++ b/heartbeat/init.sls
@@ -12,8 +12,8 @@ heartbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Heartbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/heartbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/heartbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/heartbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/heartbeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/metricbeat/init.sls
+++ b/metricbeat/init.sls
@@ -12,8 +12,8 @@ metricbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Metricbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/metricbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/metricbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/metricbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/metricbeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/packetbeat/init.sls
+++ b/packetbeat/init.sls
@@ -12,8 +12,8 @@ packetbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Packetbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/packetbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/packetbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/packetbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/packetbeat/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/patchmypc/init.sls
+++ b/patchmypc/init.sls
@@ -1,10 +1,10 @@
 patchmypc:
   {% for version in [
-                        'latest' 
+                        'latest'
                     ] %}
   '{{ version }}':
     full_name: 'Patch My PC Home Updater'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/patchmypc/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/patchmypc/install.cmd'
     install_flags: '"https://patchmypc.com/freeupdater/PatchMyPC.exe" "PatchMyPC.exe" "{{ version }}"'
     uninstaller: ''
     uninstall_flags: ''

--- a/pfsensebackup/init.sls
+++ b/pfsensebackup/init.sls
@@ -15,14 +15,14 @@
 #
 pfsensebackup:
   {% for version in ['2.6.0',
-                     '2.5.2', 
-                     '2.5.1', 
+                     '2.5.2',
+                     '2.5.1',
                      '2.5'] %}
   '{{ version }}':
     full_name: 'pfSenseBackup {{ version }}'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/pfsensebackup/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/pfsensebackup/install.cmd'
     install_flags: '"{{ version }}"'
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/pfsensebackup/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/pfsensebackup/remove.cmd'
     uninstall_flags: '"{{ version }}"'
     cache_dir: True
   {% endfor %}

--- a/pycharm-pro/init.sls
+++ b/pycharm-pro/init.sls
@@ -10,8 +10,8 @@ pycharm-pro:
   {{ build }}:
     installer: '{{ url }}/pycharm-professional-{{ version }}.exe'
     full_name: 'JetBrains Pycharm {{ version }}'
-    install_flags: '/S /CONFIG="C:\ProgramData\Salt Project\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng\pycharm-pro\silent.config"'
-    cache_file: salt://win/repo-ng/salt-winrepo-ng/pycharm-pro/silent.config
+    install_flags: '/S /CONFIG="C:\ProgramData\Salt Project\salt\var\cache\salt\minion\files\base\win\repo-ng\salt-winrepo-ng\_\pycharm-pro\silent.config"'
+    cache_file: salt://win/repo-ng/salt-winrepo-ng/_/pycharm-pro/silent.config
     uninstaller: '{{ PROGRAM_FILES }}\JetBrains\PyCharm {{ version }}\Uninstall.exe'
     uninstall_flags: '/S'
     msiexec: False

--- a/rsync-git/init.sls
+++ b/rsync-git/init.sls
@@ -14,8 +14,8 @@ rsync-git:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'rSync for Git'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/rsync-git/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/rsync-git/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/rsync-git/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/rsync-git/remove.cmd'
     cache_dir: True
 {% endfor %}

--- a/stayawake/init.sls
+++ b/stayawake/init.sls
@@ -8,8 +8,8 @@ stayawake:
   {% for version in ['1.0'] %}
   '{{ version }}':
     full_name: 'StayAwake'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/stayawake/install.cmd'
-    install_flags: '"https://downloads.sourceforge.net/projects/stayawake/" "StayAwake-setup.exe" "1.0" "/S"' 
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/stayawake/install.cmd'
+    install_flags: '"https://downloads.sourceforge.net/projects/stayawake/" "StayAwake-setup.exe" "1.0" "/S"'
     uninstaller: '{{ PROGRAM_FILES }}\StayAwake\uninstall.exe'
     uninstall_flags: '/S'
   {% endfor %}

--- a/topgrade/init.sls
+++ b/topgrade/init.sls
@@ -122,11 +122,11 @@ topgrade:
                         '0.12.0',
                         '0.11.0',
                         '0.10.0',
-                        '0.9.0' 
+                        '0.9.0'
                     ] %}
   '{{ version }}':
     full_name: 'TopGrade'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/topgrade/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/topgrade/install.cmd'
     install_flags: '"https://github.com/r-darwish/topgrade/releases/download/v{{ version }}/topgrade-v{{version }}-x86_64-pc-windows-msvc.zip" "topgrade-v{{version }}-x86_64-pc-windows-msvc.zip" "{{ version }}"'
     uninstaller: ''
     uninstall_flags: ''

--- a/winlogbeat/init.sls
+++ b/winlogbeat/init.sls
@@ -23,8 +23,8 @@ winlogbeat:
 {% for version in versions %}
   '{{ version }}':
     full_name: 'Winlogbeat'
-    installer: 'salt://win/repo-ng/salt-winrepo-ng/winlogbeat/install.cmd'
+    installer: 'salt://win/repo-ng/salt-winrepo-ng/_/winlogbeat/install.cmd'
     install_flags: {{ version }}
-    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/winlogbeat/remove.cmd'
+    uninstaller: 'salt://win/repo-ng/salt-winrepo-ng/_/winlogbeat/remove.cmd'
     cache_dir: True
 {% endfor %}


### PR DESCRIPTION
The `winrepo.update_git_repos` creates a directory named `salt-winrepo-ng_git`. The directory based installations are all looking in `salt-winrepo-ng`. If you try to install any of these they can't find their resources because they're looking in the wrong location.