### PR TITLE
ci(renovate): use correct source for Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Run `pre-commit`
     runs-on: ubuntu-latest
     env:
-      # renovate: datasource=github-tags depName=python/cpython
+      # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
       PYTHON_VERSION: 3.12.3
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4


### PR DESCRIPTION
* `actions/python-versions` represents the actual versions of Python available to `actions/setup-python`