### PR TITLE
ci(renovate): fix version extraction for `firefox-esr`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,6 +36,10 @@
       "extractVersion": "putty-64bit-(?<version>.+)-installer.msi$"
     },
     {
+      "matchDepNames": ["firefox-esr"],
+      "extractVersion": "(?<version>.+)esr$",
+    },
+    {
       "matchPackageNames": ["python/cpython"],
       "separateMinorPatch": true,
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -33,7 +33,7 @@
   "packageRules": [
     {
       "matchDatasources": ["custom.putty"],
-      "extractVersion": "putty-64bit-(?<version>.+)-installer.msi$"
+      "extractVersion": "putty-64bit-(?<version>.+)-installer\\.msi$",
     },
     {
       "matchDepNames": ["firefox-esr"],


### PR DESCRIPTION
- **ci(renovate): fix version extraction for `firefox-esr`**
- **ci(renovate): fix escaping for `putty`**
