### PR TITLE
ci(renovate): change default versioning for our custom manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,7 @@
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>\\S+?)(?: packageName=(?<packageName>\\S+?))?\\s+- [\"']?(?<currentValue>.+?)[\"']?\\s",
       ],
       "autoReplaceStringTemplate": "# renovate: datasource={{{datasource}}} depName={{{depName}}}{{#unless (equals depName packageName)}} packageName={{{packageName}}}{{/unless}}\n- '{{{newValue}}}'\n- '{{{currentValue}}}'\n",
+      "versioningTemplate": "loose",
     },
   ],
   "packageRules": [
@@ -46,10 +47,6 @@
     {
       "matchDepNames": ["firefox-esr"],
       "extractVersion": "(?<version>.+)esr$",
-    },
-    {
-      "matchDepNames": ["7zip"],
-      "versioning": "loose",
     },
     {
       "matchPackageNames": ["python/cpython"],


### PR DESCRIPTION
* change versioning to `loose` which better represents most versions we deal with
* a package rule can be used to set versioning for a specific packkage when needed
