### PR TITLE
chore: use action to wait for status checks to complete

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,10 +109,12 @@ jobs:
           & "C:\Program Files\Salt Project\Salt\Scripts\python.exe" .\.cicd\tests.py ${{ join(fromJSON(steps.changed-files.outputs.sls_files), ' ') }}
   results:
     name: Collect results
-    needs:
-      - pre-commit
-      - refresh_db
-      - test
+    permissions:
+      checks: read
     runs-on: ubuntu-latest
     steps:
+      - uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
+        with:
+          ignore: Collect results
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo "Tests succeeded!"


### PR DESCRIPTION
* `needs` makes the `results` job conditional (i.e. GitHub Actions isnt sure whether it will ever run)
   and this breaks "required status checks` and auto-merging
* Use action `wait-for-status-checks` which waits until all checks have completed
