### PR TITLE
chore(renovate): prevent failed updates by reading the actual available Python version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,12 @@
         "defaultRegistryUrlTemplate": "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html",
         "format": "html",
       },
+      "python-versions": {
+        "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/actions/python-versions/refs/heads/main/versions-manifest.json",
+        "transformTemplates": [
+          "{\"releases\": $ }",
+        ],
+      },
       "vlc": {
         "defaultRegistryUrlTemplate": "https://get.videolan.org/vlc/last/win64/",
         "format": "html",
@@ -47,10 +53,6 @@
     {
       "matchDepNames": ["firefox-esr"],
       "extractVersion": "(?<version>.+)esr$",
-    },
-    {
-      "matchPackageNames": ["python/cpython"],
-      "separateMinorPatch": true,
     },
     {
       // Salt major version releases must be added manually to the sls file

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     if: fromJSON(needs.should-run.outputs.should-run)
     runs-on: ubuntu-latest
     env:
-      # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
+      # renovate: datasource=custom.python-versions depName=actions/python-versions versioning=pep440
       PYTHON_VERSION: 3.13.0
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
* read the available versions from the upstream manifest file
