### PR TITLE
Update URL for Salt packages

### DIFF
--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -15,7 +15,7 @@
 # Use Renovate to apply automatic version updates. Due to the way Renovate works
 # each major version must be updated separately (otherwise all versions would be
 # updated to the latest version). New major versions e.g. 3008.0 must be added manually.
-{%- load_yaml as versions_relenv %}
+{%- load_yaml as relenv_versions %}
 # renovate: datasource=github-tags depName=salt-3007.x packageName=saltstack/salt
 - 3007.1
 - 3007.0
@@ -118,7 +118,7 @@
 
 salt-minion-py3:
   # RELENV VERSIONS
-  {%- for version in versions_relenv %}
+  {%- for version in relenv_versions %}
   '{{ version }}':
     full_name: 'Salt Minion {{ version }} (Python 3)'
     {% if grains['cpuarch'] == 'AMD64' -%}
@@ -138,7 +138,7 @@ salt-minion-py3:
   {% endfor -%}
 
   # REMOVE ONLY VERSIONS (CVE, Unsupported, Missing Artifacts)
-  {%- for version in remove_only_version %}
+  {%- for version in remove_only_versions %}
   '{{ version }}':
     skip_urltest: True
     full_name: 'Salt Minion {{ version }} (Python 3)'

--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -26,26 +26,24 @@
 - 3006.6
 {%- endload %}
 
-# Starting in Version 3004 salt is installed in ProgramData by default
-# The uninstaller will be in ProgramData\Salt Project\Salt
-{%- load_yaml as versions_classic %}
-- 3005.5
-{%- endload %}
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Versions of Salt that contain CVE's have been moved to an archive at:
 # archive.repo.saltstack.com/windows. The ability to install those versions
 # using winrepo has been removed.
 # An uninstall only definition will remain here so the packages will show up
 # correctly in `pkg.list_pkgs` and to allow for removal using `pkg.remove`
+# Additionally, as of 2024-10-30 packages are no longer hosted on AWS. As part
+# of the migration, only the latest 2 major versions are available for
+# download.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-{%- load_yaml as versions_cve %}
+{%- load_yaml as remove_only_versions %}
 - 3006.5
 - 3006.4
 - 3006.3
 - 3006.2
 - 3006.1
 - 3006.0
+- 3005.5
 - 3005.4
 - 3005.3
 - 3005.2
@@ -124,9 +122,9 @@ salt-minion-py3:
   '{{ version }}':
     full_name: 'Salt Minion {{ version }} (Python 3)'
     {% if grains['cpuarch'] == 'AMD64' -%}
-    installer: 'https://repo.saltproject.io/salt/py3/windows/minor/{{ version }}/Salt-Minion-{{ version }}-Py3-AMD64-Setup.exe'
+    installer: 'https://packages.broadcom.com/artifactory/saltproject-generic/windows/{{ version }}/Salt-Minion-{{ version }}-Py3-AMD64-Setup.exe'
     {% else -%}
-    installer: 'https://repo.saltproject.io/salt/py3/windows/minor/{{ version }}/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
+    installer: 'https://packages.broadcom.com/artifactory/saltproject-generic/windows/{{ version }}/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
     {% endif -%}
     {% raw -%}
     # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
@@ -139,28 +137,8 @@ salt-minion-py3:
     reboot: False
   {% endfor -%}
 
-  # CLASSIC VERSIONS
-  {%- for version in versions_classic %}
-  '{{ version }}':
-    full_name: 'Salt Minion {{ version }} (Python 3)'
-    {% if grains['cpuarch'] == 'AMD64' -%}
-    installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-AMD64-Setup.exe'
-    {% else -%}
-    installer: 'https://repo.saltproject.io/windows/Salt-Minion-{{ version }}-Py3-x86-Setup.exe'
-    {% endif -%}
-    {% raw -%}
-    # install_flags: "/S /master={{ salt['pillar.get']('salt:master', 'salt.domain.tld') }} /minion-id={{ salt['pillar.get']('salt:minion:ids:' ~ grains['host'] }}"
-    {% endraw -%}
-    install_flags: '/S'
-    uninstaller: '{{ install_dir }}\uninst.exe'
-    uninstall_flags: '/S'
-    msiexec: False
-    use_scheduler: True
-    reboot: False
-  {% endfor -%}
-
-  # CVE VERSIONS (REMOVE ONLY)
-  {%- for version in versions_cve %}
+  # REMOVE ONLY VERSIONS (CVE, Unsupported, Missing Artifacts)
+  {%- for version in remove_only_version %}
   '{{ version }}':
     skip_urltest: True
     full_name: 'Salt Minion {{ version }} (Python 3)'


### PR DESCRIPTION
Salt recently had to migrate everything off of AWS. Our only option is to use Broadcom's artifactory. This will update the URLs in the package definition for Salt.
Also, as part of this transition, all archive and unsupported versions will not be hosted. Those have also been moved to remove only support.

Fixes https://github.com/saltstack/salt-winrepo-ng/issues/2216