### PR TITLE
fix(nsclient): v0.5.3.4 was missing a padded zero in its display version

### DIFF
--- a/nsclient.sls
+++ b/nsclient.sls
@@ -1,4 +1,4 @@
-{%- load_yaml as versions %}
+{% load_yaml as versions -%}
 # renovate: datasource=github-releases depName=nscp packageName=mickem/nscp
 - '0.5.3.4'
 - '0.5.2.39'
@@ -10,7 +10,7 @@
 - '0.4.4.19'
 - '0.4.3.143'
 - '0.4.3.88'
-{%- endload%}
+{% endload -%}
 
 {%- if grains["cpuarch"] == "x86" %}
   {%- set arch_file = "Win32" %}
@@ -27,12 +27,9 @@ nsclient:
   {%- endif %}
 
   '{{ display_version|d(version) }}':
-    full_name:  'NSClient++ ({{ arch_name|d("x64") }})'
-    installer: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file|d("x64") }}.msi'
-    uninstaller: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file|d("x64") }}.msi'
-    install_flags: '/quiet'
-    uninstall_flags: '/quiet'
-    msiexec: True
-    locale: en_US
-    reboot: False
+    full_name:  NSClient++ ({{ arch_name|d("x64") }})
+    installer: https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file|d("x64") }}.msi
+    install_flags: /quiet
+    uninstall_flags: /quiet
+    msiexec: true
 {%- endfor %}

--- a/nsclient.sls
+++ b/nsclient.sls
@@ -22,16 +22,14 @@
 
 nsclient:
 {%- for version in versions %}
-  # This is to handle the version reported in Windows
-  {%- set major, minor, maint, build = version.split(".") %}
-  {%- if minor|int >= 5 %} # version 5 and newer has 2 dots (0.5.2039)
-    {%- set install_version = ".".join([major, minor, maint]) %}
-    {%- set install_version = "0".join([install_version, build]) %}
-  {%- else %} # version 4 and lower has 3 dots (0.4.4.23)
-    {%- set install_version = version %}
+  {#- v0.5.x.x Windows display versions have only three parts (e.g. 0.5.2039) #}
+  {%- if (salt["pkg.compare_versions"](version, "<", "0.6") and
+          salt["pkg.compare_versions"](version, ">=", "0.5")) %}
+    {%- set major, minor, patch, build = version.split(".") %}
+    {%- set display_version = ".".join([major, minor, patch]) + build.zfill(3) %}
   {%- endif %}
 
-  '{{ install_version }}':
+  '{{ display_version|d(version) }}':
     full_name:  'NSClient++ ({{ arch_name }})'
     installer: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file }}.msi'
     uninstaller: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file }}.msi'

--- a/nsclient.sls
+++ b/nsclient.sls
@@ -11,11 +11,8 @@
 - '0.4.3.143'
 - '0.4.3.88'
 {%- endload%}
-# This is to handle the architecture
-{%- if grains['cpuarch'] == 'AMD64' %}
-  {%- set arch_file = "x64" %}
-  {%- set arch_name = "x64" %}
-{%- else %}
+
+{%- if grains["cpuarch"] == "x86" %}
   {%- set arch_file = "Win32" %}
   {%- set arch_name = "x86" %}
 {%- endif %}
@@ -30,9 +27,9 @@ nsclient:
   {%- endif %}
 
   '{{ display_version|d(version) }}':
-    full_name:  'NSClient++ ({{ arch_name }})'
-    installer: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file }}.msi'
-    uninstaller: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file }}.msi'
+    full_name:  'NSClient++ ({{ arch_name|d("x64") }})'
+    installer: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file|d("x64") }}.msi'
+    uninstaller: 'https://github.com/mickem/nscp/releases/download/{{ version }}/NSCP-{{ version }}-{{ arch_file|d("x64") }}.msi'
     install_flags: '/quiet'
     uninstall_flags: '/quiet'
     msiexec: True


### PR DESCRIPTION
- **fix(nsclient): v0.5.3.4 was missing a padded zero in its display version**
- **refactor(nsclient): simplify architecture handling**
- **style(nsclient): update with preferred styling**
