### PR TITLE
test: load `minion_mods` rather than use Salt Caller API

### DIFF
--- a/.cicd/requirements.txt
+++ b/.cicd/requirements.txt
@@ -1,2 +1,4 @@
 python-magic-bin==0.4.14
 tabulate==0.9.0
+
+saltext.test-salt-winrepo==0.1.1


### PR DESCRIPTION
  * This avoids a subtle bug where CPU architecture grains are not
    updated until the next Caller instance is created. This gives
    the appearance that the architecture labels are reversed, however
    it also means that the first set of URLs tested are always AMD64 only,
    and so all architectures are not correctly tested.
  * The new method uses the loader to load a set of `minion_mods` for
    each architecture specifying the required grains explicitly.
  * This requires a Salt extension to be installed in the Salt Python
    environment to provide a dummy module to replace the
    Windows-specific `reg` module. This makes the tests more
    deterministic and platform-independent, meaning the tests can be run
    & developed on other platforms like MacOS or Linux.
  * The new method has revealed some test failures in a number of package definitions
    which will need to be fixed after this PR is merged.

Compare:
<details>
<summary> Test URLs result for current test method</summary>

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>> ( salt-minion.sls ) <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-------------------------------- ( arch: x86 ) ---------------------------------
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.1/Salt-Minion-3007.1-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.0/Salt-Minion-3007.0-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.10/Salt-Minion-3006.10-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.9/Salt-Minion-3006.9-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.8/Salt-Minion-3006.8-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.7/Salt-Minion-3006.7-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.6/Salt-Minion-3006.6-Py3-AMD64-Setup.exe
SKIPPED : salt-minion-py3 -- 3006.5
SKIPPED : salt-minion-py3 -- 3006.4
SKIPPED : salt-minion-py3 -- 3006.3
SKIPPED : salt-minion-py3 -- 3006.2
SKIPPED : salt-minion-py3 -- 3006.1
SKIPPED : salt-minion-py3 -- 3006.0
...
...
------------------------------- ( arch: AMD64 ) --------------------------------
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.1/Salt-Minion-3007.1-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.0/Salt-Minion-3007.0-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.10/Salt-Minion-3006.10-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.9/Salt-Minion-3006.9-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.8/Salt-Minion-3006.8-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.7/Salt-Minion-3006.7-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.6/Salt-Minion-3006.6-Py3-AMD64-Setup.exe
SKIPPED : salt-minion-py3 -- 3006.5
SKIPPED : salt-minion-py3 -- 3006.4
SKIPPED : salt-minion-py3 -- 3006.3
SKIPPED : salt-minion-py3 -- 3006.2
SKIPPED : salt-minion-py3 -- 3006.1
SKIPPED : salt-minion-py3 -- 3006.0
...
...
--------------------------------------------------------------------------------

Notice: Test Summary:
=============
Total      168
-------  -----
skipped    154
passed      14

Content Type:
=============
Total                       14
------------------------  ----
application/octet-stream    14

HTTP Codes:
===========
  Total    14
-------  ----
    200    14

********************************************************************************
Everything went smoothly. No errors were found. Happy deployment!
********************************************************************************
```
</details>

with:

<details>
<summary>Test URLs result with new method</summary>

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>> ( salt-minion.sls ) <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
------------------------------- ( arch: AMD64 ) --------------------------------
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.1/Salt-Minion-3007.1-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.0/Salt-Minion-3007.0-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.10/Salt-Minion-3006.10-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.9/Salt-Minion-3006.9-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.8/Salt-Minion-3006.8-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.7/Salt-Minion-3006.7-Py3-AMD64-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.6/Salt-Minion-3006.6-Py3-AMD64-Setup.exe
SKIPPED : salt-minion-py3 -- 3006.5
SKIPPED : salt-minion-py3 -- 3006.4
SKIPPED : salt-minion-py3 -- 3006.3
SKIPPED : salt-minion-py3 -- 3006.2
SKIPPED : salt-minion-py3 -- 3006.1
SKIPPED : salt-minion-py3 -- 3006.0
...
...
-------------------------------- ( arch: x86 ) ---------------------------------
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.1/Salt-Minion-3007.1-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3007.0/Salt-Minion-3007.0-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.10/Salt-Minion-3006.10-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.9/Salt-Minion-3006.9-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.8/Salt-Minion-3006.8-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.7/Salt-Minion-3006.7-Py3-x86-Setup.exe
VALID : https://packages.broadcom.com/artifactory/saltproject-generic/windows/3006.6/Salt-Minion-3006.6-Py3-x86-Setup.exe
SKIPPED : salt-minion-py3 -- 3006.5
SKIPPED : salt-minion-py3 -- 3006.4
SKIPPED : salt-minion-py3 -- 3006.3
SKIPPED : salt-minion-py3 -- 3006.2
SKIPPED : salt-minion-py3 -- 3006.1
SKIPPED : salt-minion-py3 -- 3006.0
...
...
--------------------------------------------------------------------------------

Notice: Test Summary:
=============
Total      168
-------  -----
skipped    154
passed      14

Content Type:
=============
Total                       14
------------------------  ----
application/octet-stream    14

HTTP Codes:
===========
  Total    14
-------  ----
    200    14

********************************************************************************
Everything went smoothly. No errors were found. Happy deployment!
********************************************************************************
```
</details>

Compare:

<details>
<summary>Full test summary for current method</summary>

```
Test Summary:
=============
Total      6277
-------  ------
passed     5621
skipped     361
failed      295
```
</details>

with:

<details>
<summary>Full test summary for new method</summary>

```
Test Summary:
=============
Total      6277
-------  ------
passed     5624
skipped     361
failed      292
```
</details>