### PR TITLE
Remove npp 8.8.4, add 8.8.5

### DIFF
--- a/npp.sls
+++ b/npp.sls
@@ -6,7 +6,8 @@
 {% endif %}
 {%- load_yaml as versions %}
 # renovate: datasource=github-releases depName=npp packageName=notepad-plus-plus/notepad-plus-plus
-- '8.8.4'
+- '8.8.5'
+# - '8.8.4' <<< npp removed release artifacts for this version
 - '8.8.3'
 - '8.8.2'
 - '8.8.1'


### PR DESCRIPTION
Looks like NotePad++ had an issue with the 8.8.4 release. Release artifacts for 8.8.4 were removed and 8.8.5 was immediately released. This PR bumps the version to 8.8.5 and removes 8.8.4.