### PR TITLE
add /ALLUSERS to gimp setup

### DIFF
--- a/gimp.sls
+++ b/gimp.sls
@@ -9,7 +9,7 @@ gimp:
   '{{ version }}':
     full_name: 'GIMP {{ version }}'
     installer: 'https://download.gimp.org/mirror/pub/gimp/{{ major_version }}/windows/gimp-{{ version }}-setup{{ minor_version }}.exe'
-    install_flags: '/SP- /SILENT /NORESTART'
+    install_flags: '/SP- /SILENT /NORESTART /ALLUSERS'
     uninstaller: '%ProgramFiles%\Gimp 2\uninst\unins000.exe'
     uninstall_flags: '/SP- /SILENT /NORESTART'
     msiexec: False


### PR DESCRIPTION
When installing gimp without /ALLUSERS it stops and asks for installation type (only current user or all users). 
Running salt-minion -l debug shows same dialog.
Running salt-minion as service setup just stops doing anything (asking in background?)

Added /ALLUSERS to install_flags of gimp and testet with older versions (2.8) for installation, deinstallation, downgrade, upgrade to current, too