### PR TITLE
rem!: remove `7zip` versions v24.01 to v24.04

### DIFF
--- a/7zip.sls
+++ b/7zip.sls
@@ -46,10 +46,6 @@
 {% set source_path = 'https://d.7-zip.org/a/' %}
 
 {%- load_yaml as versions %}
-- '24.04'
-- '24.03'
-- '24.02'
-- '24.01'
 - '19.00'
 {%- endload %}
 {%- for version in versions %}


### PR DESCRIPTION
* removed from upstream website.
