### PR TITLE
ci(workflows): switch `semantic-release-action` to commit SHA pinned container image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
             .cicd/
             .releaserc.cjs
       - id: sem-rel
-        uses: codfish/semantic-release-action@6abd188d2458e2fd6c99073454f6cc49196362e8 # v5.0.0
+        uses: docker://ghcr.io/codfish/semantic-release-action@sha256:c6a4e05d93f73f2870887434c1286df7a23a55770be16cb826b6e2432f92e650 # v5.0.0
         with:
           additional-packages: conventional-changelog-conventionalcommits@${{ env.CC_CONV_COMMITS_VERSION }}
         env:


### PR DESCRIPTION
On June 24, 2026 the GitHub Action `codfish/semantic-release-action` was compromised in an attempted supply-chain [attack](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action#stepsecurity-harden-runner-runtime-analysis).
Fortunately this repository was not affected as the GitHub Action call was pinned to a SHA commit hash and the compromise was detected before any updated tags were updated by Renovate.

However the source repository for `semantic-release-action` has been taken down by GitHub to prevent others running the malicious code; also removing our ability to run the safe version pinned in our workflows.
The maintainer of `semantic-release-action` has always built container images for the action which are still available from the GitHub Containter Registry.
Through examination of GHCR I have pinpointed the container image built from the pinned commit previously used in our workflows.

```
gh api --paginate /users/codfish/packages/container/semantic-release-action/versions \
  --jq '.[] | select(.metadata.container.tags[]? == "v5.0.0")'
{
  "created_at": "2026-02-08T03:13:52Z",
  "html_url": "https://github.com/users/codfish/packages/container/semantic-release-action/676031213",
  "id": 676031213,
  "metadata": {
    "container": {
      "tags": [
        "v5",
        "v5.0.0",
        "latest"
      ]
    },
    "package_type": "container"
  },
  "name": "sha256:c6a4e05d93f73f2870887434c1286df7a23a55770be16cb826b6e2432f92e650",
  "package_html_url": "https://github.com/users/codfish/packages/container/package/semantic-release-action",
  "updated_at": "2026-02-08T03:13:52Z",
  "url": "https://api.github.com/users/codfish/packages/container/semantic-release-action/versions/676031213"
}
```
As this container image with the digest `sha256:c6a4e05d93f73f2870887434c1286df7a23a55770be16cb826b6e2432f92e650` (created 2026-02-08) hasn't been affected by the recent compromise, I feel confident that we can safely keep using the action as-is until another solutioncan be found , if that becomes necessary.