### PR TITLE
chore: revert dependency conventional-changelog-conventionalcommits to v10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       # renovate: datasource=npm depName=conventional-changelog-conventionalcommits
-      CC_CONV_COMMITS_VERSION: 10.2.0
+      CC_CONV_COMMITS_VERSION: 9.3.1
     steps:
       - uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
         with:


### PR DESCRIPTION
* This reverts commit 5c357ae900c7d65f7866c72272deaf54363d7066
  as `semantic-release` isn't compatible with the breaking change
  introduced in v10
